### PR TITLE
Graceful (runtime) error

### DIFF
--- a/include/env/Env.hpp
+++ b/include/env/Env.hpp
@@ -1,7 +1,7 @@
 #ifndef LISP_INCLUDE_ENV_ENV_HPP_
 #define LISP_INCLUDE_ENV_ENV_HPP_
 
-#include "../repl/EvalException.hpp"
+#include "../repl/except/EvalException.hpp"
 #include "../sexpr/SExpr.hpp"
 #include <map>
 #include <memory>

--- a/include/env/Env.hpp
+++ b/include/env/Env.hpp
@@ -19,9 +19,9 @@ public:
   Env();
   Env(const shared_ptr<Env> outer);
 
-  shared_ptr<SExpr> find(string symbol) throw(EvalException);
+  shared_ptr<SExpr> find(string symbol);
 
-  void set(string symbol, shared_ptr<SExpr> val) throw(EvalException);
+  void set(string symbol, shared_ptr<SExpr> val);
 };
 
 void initEnv(shared_ptr<Env> env);

--- a/include/env/Env.hpp
+++ b/include/env/Env.hpp
@@ -1,6 +1,7 @@
 #ifndef LISP_INCLUDE_ENV_ENV_HPP_
 #define LISP_INCLUDE_ENV_ENV_HPP_
 
+#include "../repl/EvalException.hpp"
 #include "../sexpr/SExpr.hpp"
 #include <map>
 #include <memory>
@@ -18,9 +19,9 @@ public:
   Env();
   Env(const shared_ptr<Env> outer);
 
-  shared_ptr<SExpr> find(string symbol);
+  shared_ptr<SExpr> find(string symbol) throw(EvalException);
 
-  void set(string symbol, shared_ptr<SExpr> val);
+  void set(string symbol, shared_ptr<SExpr> val) throw(EvalException);
 };
 
 void initEnv(shared_ptr<Env> env);

--- a/include/repl/EvalException.hpp
+++ b/include/repl/EvalException.hpp
@@ -1,0 +1,29 @@
+#ifndef LISP_INCLUD_REPL_EVALEXCEPTION_H
+#define LISP_INCLUD_REPL_EVALEXCEPTION_H
+
+#include "../sexpr/SExpr.hpp"
+#include <exception>
+#include <memory>
+#include <string>
+#include <vector>
+
+using std::exception;
+using std::shared_ptr;
+using std::string;
+using std::vector;
+
+class EvalException : public exception {
+  string _msg;
+  vector<const shared_ptr<SExpr>> stackTrace;
+
+public:
+  EvalException(const string &msg);
+
+  virtual const char *what() const noexcept override;
+
+  void pushStackTrace(const shared_ptr<SExpr> stack);
+
+  const vector<const shared_ptr<SExpr>> &getStackTrace() const;
+};
+
+#endif

--- a/include/repl/except/EvalException.hpp
+++ b/include/repl/except/EvalException.hpp
@@ -14,16 +14,16 @@ using std::vector;
 
 class EvalException : public exception {
   string _msg;
-  vector<const shared_ptr<SExpr>> stackTrace;
+  vector<shared_ptr<SExpr>> stackTrace;
 
 public:
   EvalException(const string &msg);
 
   virtual const char *what() const noexcept override;
 
-  void pushStackTrace(const shared_ptr<SExpr> stack);
+  void pushStackTrace(shared_ptr<SExpr> stack);
 
-  const vector<const shared_ptr<SExpr>> &getStackTrace() const;
+  const vector<shared_ptr<SExpr>> &getStackTrace() const;
 };
 
 #endif

--- a/include/repl/except/EvalException.hpp
+++ b/include/repl/except/EvalException.hpp
@@ -1,7 +1,7 @@
 #ifndef LISP_INCLUD_REPL_EVALEXCEPTION_H
 #define LISP_INCLUD_REPL_EVALEXCEPTION_H
 
-#include "../sexpr/SExpr.hpp"
+#include "../../sexpr/SExpr.hpp"
 #include <exception>
 #include <memory>
 #include <string>

--- a/include/repl/repl.hpp
+++ b/include/repl/repl.hpp
@@ -2,6 +2,7 @@
 #define LISP_INCLUD_REPL_REPL
 
 #include "../env/Env.hpp"
+#include "../repl/EvalException.hpp"
 #include "../sexpr/SExpr.hpp"
 #include "../sexpr/SExprs.hpp"
 #include <memory>
@@ -20,7 +21,8 @@ shared_ptr<SExpr> parse(vector<string>::iterator &it);
 
 shared_ptr<SExpr> parse(vector<string> tokens);
 
-shared_ptr<SExpr> eval(shared_ptr<SExpr> SExpr, shared_ptr<Env> env);
+shared_ptr<SExpr> eval(shared_ptr<SExpr> SExpr,
+                       shared_ptr<Env> env) throw(EvalException);
 
 void repl();
 

--- a/include/repl/repl.hpp
+++ b/include/repl/repl.hpp
@@ -2,7 +2,7 @@
 #define LISP_INCLUD_REPL_REPL
 
 #include "../env/Env.hpp"
-#include "../repl/EvalException.hpp"
+#include "../repl/except/EvalException.hpp"
 #include "../sexpr/SExpr.hpp"
 #include "../sexpr/SExprs.hpp"
 #include <memory>

--- a/include/repl/repl.hpp
+++ b/include/repl/repl.hpp
@@ -21,8 +21,7 @@ shared_ptr<SExpr> parse(vector<string>::iterator &it);
 
 shared_ptr<SExpr> parse(vector<string> tokens);
 
-shared_ptr<SExpr> eval(shared_ptr<SExpr> SExpr,
-                       shared_ptr<Env> env) throw(EvalException);
+shared_ptr<SExpr> eval(shared_ptr<SExpr> SExpr, shared_ptr<Env> env);
 
 void repl();
 

--- a/include/sexpr/BoolAtom.hpp
+++ b/include/sexpr/BoolAtom.hpp
@@ -22,6 +22,7 @@ public:
 
   static bool toBool(const shared_ptr<SExpr> sExpr);
   static bool classOf(const SExpr &sExpr);
+  static const string typeName;
 };
 
 #endif

--- a/include/sexpr/BoolAtom.hpp
+++ b/include/sexpr/BoolAtom.hpp
@@ -23,7 +23,7 @@ public:
 
   static bool toBool(const shared_ptr<SExpr> sExpr);
 
-  static bool classOf(SExpr &sExpr);
+  static bool classOf(const SExpr &sExpr);
 };
 
 #endif

--- a/include/sexpr/BoolAtom.hpp
+++ b/include/sexpr/BoolAtom.hpp
@@ -17,11 +17,13 @@ public:
 
   BoolAtom(const shared_ptr<SExpr> sExpr);
 
-  static bool cast(const shared_ptr<SExpr> sExpr);
-
   string toString() const;
 
   bool equals(const SExpr &other) const;
+
+  static bool cast(const shared_ptr<SExpr> sExpr);
+
+  static bool classOf(const SExpr &sExpr);
 };
 
 #endif

--- a/include/sexpr/BoolAtom.hpp
+++ b/include/sexpr/BoolAtom.hpp
@@ -10,19 +10,17 @@ using std::shared_ptr;
 using std::string;
 
 class BoolAtom : public Atom {
+protected:
+  string toString() const;
+  bool equals(const SExpr &other) const;
+
 public:
   const bool val;
 
   BoolAtom(const bool val);
-
   BoolAtom(const shared_ptr<SExpr> sExpr);
 
-  string toString() const;
-
-  bool equals(const SExpr &other) const;
-
   static bool toBool(const shared_ptr<SExpr> sExpr);
-
   static bool classOf(const SExpr &sExpr);
 };
 

--- a/include/sexpr/BoolAtom.hpp
+++ b/include/sexpr/BoolAtom.hpp
@@ -21,9 +21,9 @@ public:
 
   bool equals(const SExpr &other) const;
 
-  static bool cast(const shared_ptr<SExpr> sExpr);
+  static bool toBool(const shared_ptr<SExpr> sExpr);
 
-  static bool classOf(const SExpr &sExpr);
+  static bool classOf(SExpr &sExpr);
 };
 
 #endif

--- a/include/sexpr/ClosureAtom.hpp
+++ b/include/sexpr/ClosureAtom.hpp
@@ -14,6 +14,9 @@ using std::shared_ptr;
 class ClosureAtom : public Atom {
   typedef function<shared_ptr<SExpr>(shared_ptr<Env>)> Proc;
 
+private:
+  void handleArgMismatch(shared_ptr<SExpr> argNames, shared_ptr<SExpr> argVals);
+
 public:
   Proc proc;
   const shared_ptr<Env> outerEnv;

--- a/include/sexpr/ClosureAtom.hpp
+++ b/include/sexpr/ClosureAtom.hpp
@@ -32,6 +32,8 @@ public:
   string toString() const;
 
   bool equals(const SExpr &other) const;
+
+  static bool classOf(const SExpr &sExpr);
 };
 
 #endif

--- a/include/sexpr/ClosureAtom.hpp
+++ b/include/sexpr/ClosureAtom.hpp
@@ -33,7 +33,7 @@ public:
 
   bool equals(const SExpr &other) const;
 
-  static bool classOf(const SExpr &sExpr);
+  static bool classOf(SExpr &sExpr);
 };
 
 #endif

--- a/include/sexpr/ClosureAtom.hpp
+++ b/include/sexpr/ClosureAtom.hpp
@@ -16,6 +16,13 @@ class ClosureAtom : public Atom {
 
 private:
   void handleArgMismatch(shared_ptr<SExpr> argNames, shared_ptr<SExpr> argVals);
+  std::shared_ptr<SExpr> evalArgs(shared_ptr<SExpr> args,
+                                  shared_ptr<Env> curEnv);
+  shared_ptr<Env> bindArgs(shared_ptr<SExpr> args, shared_ptr<Env> curEnv);
+
+protected:
+  string toString() const;
+  bool equals(const SExpr &other) const;
 
 public:
   Proc proc;
@@ -25,16 +32,7 @@ public:
   ClosureAtom(Proc proc, const shared_ptr<Env> outerEnv,
               const shared_ptr<SExpr> argNames);
 
-  std::shared_ptr<SExpr> evalArgs(shared_ptr<SExpr> args,
-                                  shared_ptr<Env> curEnv);
-
-  shared_ptr<Env> bindArgs(shared_ptr<SExpr> args, shared_ptr<Env> curEnv);
-
   shared_ptr<SExpr> operator()(shared_ptr<SExpr> args, shared_ptr<Env> curEnv);
-
-  string toString() const;
-
-  bool equals(const SExpr &other) const;
 
   static bool classOf(const SExpr &sExpr);
 };

--- a/include/sexpr/ClosureAtom.hpp
+++ b/include/sexpr/ClosureAtom.hpp
@@ -33,7 +33,7 @@ public:
 
   bool equals(const SExpr &other) const;
 
-  static bool classOf(SExpr &sExpr);
+  static bool classOf(const SExpr &sExpr);
 };
 
 #endif

--- a/include/sexpr/ClosureAtom.hpp
+++ b/include/sexpr/ClosureAtom.hpp
@@ -35,6 +35,7 @@ public:
   shared_ptr<SExpr> operator()(shared_ptr<SExpr> args, shared_ptr<Env> curEnv);
 
   static bool classOf(const SExpr &sExpr);
+  static const string typeName;
 };
 
 #endif

--- a/include/sexpr/IntAtom.hpp
+++ b/include/sexpr/IntAtom.hpp
@@ -2,8 +2,10 @@
 #define LISP_INCLUDE_SEXPR_INTATOM_H_
 
 #include "Atom.hpp"
+#include <memory>
 #include <string>
 
+using std::shared_ptr;
 using std::string;
 
 class IntAtom : public Atom {
@@ -15,6 +17,8 @@ public:
   string toString() const;
 
   bool equals(const SExpr &other) const;
+
+  static bool classOf(const SExpr &sExpr);
 };
 
 #endif

--- a/include/sexpr/IntAtom.hpp
+++ b/include/sexpr/IntAtom.hpp
@@ -19,6 +19,7 @@ public:
   IntAtom(const int val);
 
   static bool classOf(const SExpr &sExpr);
+  static const string typeName;
 };
 
 #endif

--- a/include/sexpr/IntAtom.hpp
+++ b/include/sexpr/IntAtom.hpp
@@ -9,14 +9,14 @@ using std::shared_ptr;
 using std::string;
 
 class IntAtom : public Atom {
+protected:
+  string toString() const;
+  bool equals(const SExpr &other) const;
+
 public:
   const int val;
 
   IntAtom(const int val);
-
-  string toString() const;
-
-  bool equals(const SExpr &other) const;
 
   static bool classOf(const SExpr &sExpr);
 };

--- a/include/sexpr/IntAtom.hpp
+++ b/include/sexpr/IntAtom.hpp
@@ -18,7 +18,7 @@ public:
 
   bool equals(const SExpr &other) const;
 
-  static bool classOf(const SExpr &sExpr);
+  static bool classOf(SExpr &sExpr);
 };
 
 #endif

--- a/include/sexpr/IntAtom.hpp
+++ b/include/sexpr/IntAtom.hpp
@@ -18,7 +18,7 @@ public:
 
   bool equals(const SExpr &other) const;
 
-  static bool classOf(SExpr &sExpr);
+  static bool classOf(const SExpr &sExpr);
 };
 
 #endif

--- a/include/sexpr/NilAtom.hpp
+++ b/include/sexpr/NilAtom.hpp
@@ -14,7 +14,7 @@ public:
 
   bool equals(const SExpr &other) const;
 
-  static bool classOf(const SExpr &sExpr);
+  static bool classOf(SExpr &sExpr);
 };
 
 #endif

--- a/include/sexpr/NilAtom.hpp
+++ b/include/sexpr/NilAtom.hpp
@@ -2,6 +2,9 @@
 #define LISP_INCLUDE_SEXPR_NILATOM_H_
 
 #include "Atom.hpp"
+#include <memory>
+
+using std::shared_ptr;
 
 class NilAtom : public Atom {
 public:
@@ -10,6 +13,8 @@ public:
   string toString() const;
 
   bool equals(const SExpr &other) const;
+
+  static bool classOf(const SExpr &sExpr);
 };
 
 #endif

--- a/include/sexpr/NilAtom.hpp
+++ b/include/sexpr/NilAtom.hpp
@@ -15,6 +15,7 @@ public:
   NilAtom();
 
   static bool classOf(const SExpr &sExpr);
+  static const string typeName;
 };
 
 #endif

--- a/include/sexpr/NilAtom.hpp
+++ b/include/sexpr/NilAtom.hpp
@@ -7,12 +7,12 @@
 using std::shared_ptr;
 
 class NilAtom : public Atom {
+protected:
+  string toString() const;
+  bool equals(const SExpr &other) const;
+
 public:
   NilAtom();
-
-  string toString() const;
-
-  bool equals(const SExpr &other) const;
 
   static bool classOf(const SExpr &sExpr);
 };

--- a/include/sexpr/NilAtom.hpp
+++ b/include/sexpr/NilAtom.hpp
@@ -14,7 +14,7 @@ public:
 
   bool equals(const SExpr &other) const;
 
-  static bool classOf(SExpr &sExpr);
+  static bool classOf(const SExpr &sExpr);
 };
 
 #endif

--- a/include/sexpr/SExpr.hpp
+++ b/include/sexpr/SExpr.hpp
@@ -8,20 +8,23 @@ using std::ostream;
 using std::string;
 
 class SExpr {
+  friend class SExprs;
+  friend ostream &operator<<(ostream &o, const SExpr &sExpr);
+  friend bool operator==(SExpr &lhs, SExpr &rhs);
+
+protected:
+  virtual string toString() const = 0;
+  virtual bool equals(const SExpr &other) const = 0;
+
 public:
   enum Type { NIL, SYM, NUM, BOOL, SEXPRS, CLOSURE };
 
   const Type type;
 
   SExpr(SExpr::Type type);
-
-  virtual string toString() const = 0;
-
-  virtual bool equals(const SExpr &other) const = 0;
-
-  friend ostream &operator<<(ostream &o, const SExpr &sExpr);
 };
 
 ostream &operator<<(ostream &o, const SExpr &sExpr);
+bool operator==(SExpr &lhs, SExpr &rhs);
 
 #endif

--- a/include/sexpr/SExprs.hpp
+++ b/include/sexpr/SExprs.hpp
@@ -16,6 +16,8 @@ public:
   string toString() const;
 
   bool equals(const SExpr &other) const;
+
+  static bool classOf(const SExpr &sExpr);
 };
 
 #endif

--- a/include/sexpr/SExprs.hpp
+++ b/include/sexpr/SExprs.hpp
@@ -17,7 +17,7 @@ public:
 
   bool equals(const SExpr &other) const;
 
-  static bool classOf(const SExpr &sExpr);
+  static bool classOf(SExpr &sExpr);
 };
 
 #endif

--- a/include/sexpr/SExprs.hpp
+++ b/include/sexpr/SExprs.hpp
@@ -17,7 +17,7 @@ public:
 
   bool equals(const SExpr &other) const;
 
-  static bool classOf(SExpr &sExpr);
+  static bool classOf(const SExpr &sExpr);
 };
 
 #endif

--- a/include/sexpr/SExprs.hpp
+++ b/include/sexpr/SExprs.hpp
@@ -3,8 +3,10 @@
 
 #include "SExpr.hpp"
 #include <memory>
+#include <string>
 
 using std::shared_ptr;
+using std::string;
 
 class SExprs : public SExpr {
 protected:
@@ -18,6 +20,7 @@ public:
   SExprs(shared_ptr<SExpr> first, shared_ptr<SExpr> rest);
 
   static bool classOf(const SExpr &sExpr);
+  static const string typeName;
 };
 
 #endif

--- a/include/sexpr/SExprs.hpp
+++ b/include/sexpr/SExprs.hpp
@@ -7,15 +7,15 @@
 using std::shared_ptr;
 
 class SExprs : public SExpr {
+protected:
+  string toString() const;
+  bool equals(const SExpr &other) const;
+
 public:
   shared_ptr<SExpr> first;
   shared_ptr<SExpr> rest;
 
   SExprs(shared_ptr<SExpr> first, shared_ptr<SExpr> rest);
-
-  string toString() const;
-
-  bool equals(const SExpr &other) const;
 
   static bool classOf(const SExpr &sExpr);
 };

--- a/include/sexpr/SymAtom.hpp
+++ b/include/sexpr/SymAtom.hpp
@@ -2,8 +2,10 @@
 #define LISP_INCLUDE_SEXPR_SYMATOM_H_
 
 #include "Atom.hpp"
+#include <memory>
 #include <string>
 
+using std::shared_ptr;
 using std::string;
 
 class SymAtom : public Atom {
@@ -15,6 +17,8 @@ public:
   string toString() const;
 
   bool equals(const SExpr &other) const;
+
+  static bool classOf(const SExpr &sExpr);
 };
 
 #endif

--- a/include/sexpr/SymAtom.hpp
+++ b/include/sexpr/SymAtom.hpp
@@ -9,14 +9,14 @@ using std::shared_ptr;
 using std::string;
 
 class SymAtom : public Atom {
+protected:
+  string toString() const;
+  bool equals(const SExpr &other) const;
+
 public:
   const string val;
 
   SymAtom(string val);
-
-  string toString() const;
-
-  bool equals(const SExpr &other) const;
 
   static bool classOf(const SExpr &sExpr);
 };

--- a/include/sexpr/SymAtom.hpp
+++ b/include/sexpr/SymAtom.hpp
@@ -19,6 +19,7 @@ public:
   SymAtom(string val);
 
   static bool classOf(const SExpr &sExpr);
+  static const string typeName;
 };
 
 #endif

--- a/include/sexpr/SymAtom.hpp
+++ b/include/sexpr/SymAtom.hpp
@@ -18,7 +18,7 @@ public:
 
   bool equals(const SExpr &other) const;
 
-  static bool classOf(const SExpr &sExpr);
+  static bool classOf(SExpr &sExpr);
 };
 
 #endif

--- a/include/sexpr/SymAtom.hpp
+++ b/include/sexpr/SymAtom.hpp
@@ -18,7 +18,7 @@ public:
 
   bool equals(const SExpr &other) const;
 
-  static bool classOf(SExpr &sExpr);
+  static bool classOf(const SExpr &sExpr);
 };
 
 #endif

--- a/makefile
+++ b/makefile
@@ -1,8 +1,8 @@
 CXX = g++
 CXXFLAGS = -std=c++11
 
-out/lisp: out/main.o out/repl.o out/functions.o out/Env.o out/SymAtom.o out/SExprs.o out/SExpr.o out/NilAtom.o out/IntAtom.o out/ClosureAtom.o out/BoolAtom.o out/Atom.o
-	$(CXX) $(CXXFLAGS) out/main.o out/repl.o out/functions.o out/Env.o out/SymAtom.o out/SExprs.o out/SExpr.o out/NilAtom.o out/IntAtom.o out/ClosureAtom.o out/BoolAtom.o out/Atom.o -o out/lisp
+out/lisp: out/main.o out/repl.o out/functions.o out/Env.o out/SymAtom.o out/SExprs.o out/SExpr.o out/NilAtom.o out/IntAtom.o out/ClosureAtom.o out/BoolAtom.o out/Atom.o out/cast.o
+	$(CXX) $(CXXFLAGS) out/main.o out/repl.o out/functions.o out/Env.o out/SymAtom.o out/SExprs.o out/SExpr.o out/NilAtom.o out/IntAtom.o out/ClosureAtom.o out/BoolAtom.o out/Atom.o out/cast.o -o out/lisp
 
 out/main.o: src/repl/main.cpp
 	$(CXX) $(CXXFLAGS) -c src/repl/main.cpp -o out/main.o
@@ -39,6 +39,9 @@ out/BoolAtom.o: src/sexpr/BoolAtom.cpp
 
 out/Atom.o: src/sexpr/Atom.cpp
 	$(CXX) $(CXXFLAGS) -c src/sexpr/Atom.cpp -o out/Atom.o
+
+out/cast.o: src/sexpr/cast.cpp
+	$(CXX) $(CXXFLAGS) -c src/sexpr/cast.cpp -o out/cast.o
 
 test: testParse testHof testCons testRecur testCombine testSet testPred
 

--- a/makefile
+++ b/makefile
@@ -43,8 +43,8 @@ out/Atom.o: src/sexpr/Atom.cpp
 out/cast.o: src/sexpr/cast.cpp
 	$(CXX) $(CXXFLAGS) -c src/sexpr/cast.cpp -o out/cast.o
 	
-out/EvalException.o: src/repl/EvalException.cpp
-	$(CXX) $(CXXFLAGS) -c src/repl/EvalException.cpp -o out/EvalException.o
+out/EvalException.o: src/repl/except/EvalException.cpp
+	$(CXX) $(CXXFLAGS) -c src/repl/except/EvalException.cpp -o out/EvalException.o
 
 test: testParse testHof testCons testRecur testCombine testSet testPred
 

--- a/makefile
+++ b/makefile
@@ -1,8 +1,8 @@
 CXX = g++
 CXXFLAGS = -std=c++11
 
-out/lisp: out/main.o out/repl.o out/functions.o out/Env.o out/SymAtom.o out/SExprs.o out/SExpr.o out/NilAtom.o out/IntAtom.o out/ClosureAtom.o out/BoolAtom.o out/Atom.o out/cast.o
-	$(CXX) $(CXXFLAGS) out/main.o out/repl.o out/functions.o out/Env.o out/SymAtom.o out/SExprs.o out/SExpr.o out/NilAtom.o out/IntAtom.o out/ClosureAtom.o out/BoolAtom.o out/Atom.o out/cast.o -o out/lisp
+out/lisp: out/main.o out/repl.o out/functions.o out/Env.o out/SymAtom.o out/SExprs.o out/SExpr.o out/NilAtom.o out/IntAtom.o out/ClosureAtom.o out/BoolAtom.o out/Atom.o out/cast.o out/EvalException.o
+	$(CXX) $(CXXFLAGS) out/main.o out/repl.o out/functions.o out/Env.o out/SymAtom.o out/SExprs.o out/SExpr.o out/NilAtom.o out/IntAtom.o out/ClosureAtom.o out/BoolAtom.o out/Atom.o out/cast.o out/EvalException.o -o out/lisp
 
 out/main.o: src/repl/main.cpp
 	$(CXX) $(CXXFLAGS) -c src/repl/main.cpp -o out/main.o
@@ -42,6 +42,9 @@ out/Atom.o: src/sexpr/Atom.cpp
 
 out/cast.o: src/sexpr/cast.cpp
 	$(CXX) $(CXXFLAGS) -c src/sexpr/cast.cpp -o out/cast.o
+	
+out/EvalException.o: src/repl/EvalException.cpp
+	$(CXX) $(CXXFLAGS) -c src/repl/EvalException.cpp -o out/EvalException.o
 
 test: testParse testHof testCons testRecur testCombine testSet testPred
 

--- a/src/env/Env.cpp
+++ b/src/env/Env.cpp
@@ -1,5 +1,6 @@
 #include "../../include/env/Env.hpp"
 #include "../../include/env/functions.hpp"
+#include "../../include/repl/EvalException.hpp"
 #include "../../include/repl/repl.hpp"
 #include "../../include/sexpr/ClosureAtom.hpp"
 #include "../../include/sexpr/NilAtom.hpp"
@@ -17,32 +18,31 @@ using std::make_pair;
 using std::make_shared;
 using std::shared_ptr;
 using std::string;
+using std::to_string;
 
 Env::Env() {}
 
 Env::Env(const shared_ptr<Env> outer) : outer(outer) {}
 
-shared_ptr<SExpr> Env::find(string name) {
+shared_ptr<SExpr> Env::find(string name) throw(EvalException) {
   auto it = symTable.find(name);
   if (it != symTable.end()) {
     return it->second;
   }
   if (!outer) {
-    cerr << "Fatal: symbol \"" << name << "\" is undefined" << endl;
-    exit(EXIT_FAILURE);
+    throw EvalException("Undefined symbol \"" + name + "\"");
   }
   return outer->find(name);
 }
 
-void Env::set(string name, shared_ptr<SExpr> val) {
+void Env::set(string name, shared_ptr<SExpr> val) throw(EvalException) {
   auto it = symTable.find(name);
   if (it != symTable.end()) {
     symTable[name] = val;
     return;
   }
   if (!outer) {
-    cerr << "Fatal: symbol \"" << name << "\" is undefined" << endl;
-    exit(EXIT_FAILURE);
+    throw EvalException("Undefined symbol \"" + name + "\"");
   }
   outer->set(name, val);
 }

--- a/src/env/Env.cpp
+++ b/src/env/Env.cpp
@@ -6,13 +6,13 @@
 #include "../../include/sexpr/NilAtom.hpp"
 #include "../../include/sexpr/SExpr.hpp"
 #include "../../include/sexpr/SExprs.hpp"
+#include "../sexpr/cast.cpp"
 #include <iostream>
 #include <memory>
 #include <string>
 #include <utility>
 
 using std::cerr;
-using std::dynamic_pointer_cast;
 using std::endl;
 using std::make_pair;
 using std::make_shared;
@@ -51,104 +51,97 @@ void initEnv(shared_ptr<Env> env) {
   env->symTable.insert(make_pair(
       "quit", make_shared<ClosureAtom>(lispQuit, env, make_shared<NilAtom>())));
   env->symTable.insert(make_pair(
-      "display", make_shared<ClosureAtom>(lispDisplay, env,
-                                          dynamic_pointer_cast<SExprs>(parse(
-                                              tokenize("(display_oprand)"))))));
+      "display", make_shared<ClosureAtom>(
+                     lispDisplay, env,
+                     cast<SExprs>(parse(tokenize("(display_oprand)"))))));
   env->symTable.insert(make_pair(
-      "abs", make_shared<ClosureAtom>(lispAdd, env,
-                                      dynamic_pointer_cast<SExprs>(
-                                          parse(tokenize("(abs_oprand)"))))));
+      "abs", make_shared<ClosureAtom>(
+                 lispAdd, env, cast<SExprs>(parse(tokenize("(abs_oprand)"))))));
+  env->symTable.insert(
+      make_pair("+", make_shared<ClosureAtom>(
+                         lispAdd, env,
+                         cast<SExprs>(parse(tokenize("(add_lhs add_rhs)"))))));
+  env->symTable.insert(
+      make_pair("-", make_shared<ClosureAtom>(
+                         lispSub, env,
+                         cast<SExprs>(parse(tokenize("(sub_lhs sub_rhs)"))))));
   env->symTable.insert(make_pair(
-      "+", make_shared<ClosureAtom>(lispAdd, env,
-                                    dynamic_pointer_cast<SExprs>(parse(
-                                        tokenize("(add_lhs add_rhs)"))))));
+      "*", make_shared<ClosureAtom>(
+               lispMult, env,
+               cast<SExprs>(parse(tokenize("(mult_lhs mult_rhs)"))))));
+  env->symTable.insert(
+      make_pair("/", make_shared<ClosureAtom>(
+                         lispDiv, env,
+                         cast<SExprs>(parse(tokenize("(div_lhs div_rhs)"))))));
+  env->symTable.insert(
+      make_pair("%", make_shared<ClosureAtom>(
+                         lispMod, env,
+                         cast<SExprs>(parse(tokenize("(mod_lhs mod_rhs)"))))));
   env->symTable.insert(make_pair(
-      "-", make_shared<ClosureAtom>(lispSub, env,
-                                    dynamic_pointer_cast<SExprs>(parse(
-                                        tokenize("(sub_lhs sub_rhs)"))))));
+      "=", make_shared<ClosureAtom>(
+               lispEq, env, cast<SExprs>(parse(tokenize("(eq_lhs eq_rhs)"))))));
   env->symTable.insert(make_pair(
-      "*", make_shared<ClosureAtom>(lispMult, env,
-                                    dynamic_pointer_cast<SExprs>(parse(
-                                        tokenize("(mult_lhs mult_rhs)"))))));
+      ">", make_shared<ClosureAtom>(
+               lispGt, env, cast<SExprs>(parse(tokenize("(gt_lhs gt_rhs)"))))));
   env->symTable.insert(make_pair(
-      "/", make_shared<ClosureAtom>(lispDiv, env,
-                                    dynamic_pointer_cast<SExprs>(parse(
-                                        tokenize("(div_lhs div_rhs)"))))));
+      ">=", make_shared<ClosureAtom>(
+                lispGteq, env,
+                cast<SExprs>(parse(tokenize("(gteq_lhs gteq_rhs)"))))));
   env->symTable.insert(make_pair(
-      "%", make_shared<ClosureAtom>(lispMod, env,
-                                    dynamic_pointer_cast<SExprs>(parse(
-                                        tokenize("(mod_lhs mod_rhs)"))))));
+      "<", make_shared<ClosureAtom>(
+               lispLt, env, cast<SExprs>(parse(tokenize("(lt_lhs lt_rhs)"))))));
   env->symTable.insert(make_pair(
-      "=", make_shared<ClosureAtom>(lispEq, env,
-                                    dynamic_pointer_cast<SExprs>(
-                                        parse(tokenize("(eq_lhs eq_rhs)"))))));
+      "<=", make_shared<ClosureAtom>(
+                lispLteq, env,
+                cast<SExprs>(parse(tokenize("(lteq_lhs lteq_rhs)"))))));
   env->symTable.insert(make_pair(
-      ">", make_shared<ClosureAtom>(lispGt, env,
-                                    dynamic_pointer_cast<SExprs>(
-                                        parse(tokenize("(gt_lhs gt_rhs)"))))));
+      "not", make_shared<ClosureAtom>(
+                 lispNot, env, cast<SExprs>(parse(tokenize("(not_oprand)"))))));
   env->symTable.insert(make_pair(
-      ">=", make_shared<ClosureAtom>(lispGteq, env,
-                                     dynamic_pointer_cast<SExprs>(parse(
-                                         tokenize("(gteq_lhs gteq_rhs)"))))));
+      "and",
+      make_shared<ClosureAtom>(
+          lispAnd, env, cast<SExprs>(parse(tokenize("(and_lhs and_rhs)"))))));
+  env->symTable.insert(
+      make_pair("or", make_shared<ClosureAtom>(
+                          lispOr, env,
+                          cast<SExprs>(parse(tokenize("(or_lhs or_rhs)"))))));
   env->symTable.insert(make_pair(
-      "<", make_shared<ClosureAtom>(lispLt, env,
-                                    dynamic_pointer_cast<SExprs>(
-                                        parse(tokenize("(lt_lhs lt_rhs)"))))));
+      "cons", make_shared<ClosureAtom>(
+                  lispCons, env,
+                  cast<SExprs>(parse(tokenize("(cons_lhs cons_rhs)"))))));
   env->symTable.insert(make_pair(
-      "<=", make_shared<ClosureAtom>(lispLteq, env,
-                                     dynamic_pointer_cast<SExprs>(parse(
-                                         tokenize("(lteq_lhs lteq_rhs)"))))));
+      "car", make_shared<ClosureAtom>(
+                 lispCar, env, cast<SExprs>(parse(tokenize("(car_oprand)"))))));
   env->symTable.insert(make_pair(
-      "not", make_shared<ClosureAtom>(lispNot, env,
-                                      dynamic_pointer_cast<SExprs>(
-                                          parse(tokenize("(not_oprand)"))))));
-  env->symTable.insert(make_pair(
-      "and", make_shared<ClosureAtom>(lispAnd, env,
-                                      dynamic_pointer_cast<SExprs>(parse(
-                                          tokenize("(and_lhs and_rhs)"))))));
-  env->symTable.insert(make_pair(
-      "or", make_shared<ClosureAtom>(lispOr, env,
-                                     dynamic_pointer_cast<SExprs>(
-                                         parse(tokenize("(or_lhs or_rhs)"))))));
-  env->symTable.insert(make_pair(
-      "cons", make_shared<ClosureAtom>(lispCons, env,
-                                       dynamic_pointer_cast<SExprs>(parse(
-                                           tokenize("(cons_lhs cons_rhs)"))))));
-  env->symTable.insert(make_pair(
-      "car", make_shared<ClosureAtom>(lispCar, env,
-                                      dynamic_pointer_cast<SExprs>(
-                                          parse(tokenize("(car_oprand)"))))));
-  env->symTable.insert(make_pair(
-      "cdr", make_shared<ClosureAtom>(lispCdr, env,
-                                      dynamic_pointer_cast<SExprs>(
-                                          parse(tokenize("(cdr_oprand)"))))));
-  env->symTable.insert(make_pair(
-      "null?", make_shared<ClosureAtom>(lispIsNull, env,
-                                        dynamic_pointer_cast<SExprs>(parse(
-                                            tokenize("(null?_oprand)"))))));
+      "cdr", make_shared<ClosureAtom>(
+                 lispCdr, env, cast<SExprs>(parse(tokenize("(cdr_oprand)"))))));
+  env->symTable.insert(
+      make_pair("null?", make_shared<ClosureAtom>(
+                             lispIsNull, env,
+                             cast<SExprs>(parse(tokenize("(null?_oprand)"))))));
+
+  env->symTable.insert(
+      make_pair("cons?", make_shared<ClosureAtom>(
+                             lispIsCons, env,
+                             cast<SExprs>(parse(tokenize("(cons?_oprand)"))))));
+
+  env->symTable.insert(
+      make_pair("sym?", make_shared<ClosureAtom>(
+                            lispIsSym, env,
+                            cast<SExprs>(parse(tokenize("(sym?_oprand)"))))));
+
+  env->symTable.insert(
+      make_pair("num?", make_shared<ClosureAtom>(
+                            lispIsNum, env,
+                            cast<SExprs>(parse(tokenize("(num?_oprand)"))))));
+
+  env->symTable.insert(
+      make_pair("proc?", make_shared<ClosureAtom>(
+                             lispIsProc, env,
+                             cast<SExprs>(parse(tokenize("(proc?_oprand)"))))));
 
   env->symTable.insert(make_pair(
-      "cons?", make_shared<ClosureAtom>(lispIsCons, env,
-                                        dynamic_pointer_cast<SExprs>(parse(
-                                            tokenize("(cons?_oprand)"))))));
-
-  env->symTable.insert(make_pair(
-      "sym?", make_shared<ClosureAtom>(lispIsSym, env,
-                                       dynamic_pointer_cast<SExprs>(
-                                           parse(tokenize("(sym?_oprand)"))))));
-
-  env->symTable.insert(make_pair(
-      "num?", make_shared<ClosureAtom>(lispIsNum, env,
-                                       dynamic_pointer_cast<SExprs>(
-                                           parse(tokenize("(num?_oprand)"))))));
-
-  env->symTable.insert(make_pair(
-      "proc?", make_shared<ClosureAtom>(lispIsProc, env,
-                                        dynamic_pointer_cast<SExprs>(parse(
-                                            tokenize("(proc?_oprand)"))))));
-
-  env->symTable.insert(make_pair(
-      "eq?", make_shared<ClosureAtom>(lispIsEqv, env,
-                                      dynamic_pointer_cast<SExprs>(parse(
-                                          tokenize("(eq?_lhs eq?_rhs)"))))));
+      "eq?",
+      make_shared<ClosureAtom>(
+          lispIsEqv, env, cast<SExprs>(parse(tokenize("(eq?_lhs eq?_rhs)"))))));
 }

--- a/src/env/Env.cpp
+++ b/src/env/Env.cpp
@@ -30,7 +30,7 @@ shared_ptr<SExpr> Env::find(string name) {
     return it->second;
   }
   if (!outer) {
-    throw EvalException("Undefined symbol \"" + name + "\"");
+    throw EvalException("Undefined symbol \"" + name + "\".");
   }
   return outer->find(name);
 }
@@ -42,7 +42,7 @@ void Env::set(string name, shared_ptr<SExpr> val) {
     return;
   }
   if (!outer) {
-    throw EvalException("Undefined symbol \"" + name + "\"");
+    throw EvalException("Undefined symbol \"" + name + "\".");
   }
   outer->set(name, val);
 }

--- a/src/env/Env.cpp
+++ b/src/env/Env.cpp
@@ -24,7 +24,7 @@ Env::Env() {}
 
 Env::Env(const shared_ptr<Env> outer) : outer(outer) {}
 
-shared_ptr<SExpr> Env::find(string name) throw(EvalException) {
+shared_ptr<SExpr> Env::find(string name) {
   auto it = symTable.find(name);
   if (it != symTable.end()) {
     return it->second;
@@ -35,7 +35,7 @@ shared_ptr<SExpr> Env::find(string name) throw(EvalException) {
   return outer->find(name);
 }
 
-void Env::set(string name, shared_ptr<SExpr> val) throw(EvalException) {
+void Env::set(string name, shared_ptr<SExpr> val) {
   auto it = symTable.find(name);
   if (it != symTable.end()) {
     symTable[name] = val;

--- a/src/env/Env.cpp
+++ b/src/env/Env.cpp
@@ -1,6 +1,6 @@
 #include "../../include/env/Env.hpp"
 #include "../../include/env/functions.hpp"
-#include "../../include/repl/EvalException.hpp"
+#include "../../include/repl/except/EvalException.hpp"
 #include "../../include/repl/repl.hpp"
 #include "../../include/sexpr/ClosureAtom.hpp"
 #include "../../include/sexpr/NilAtom.hpp"

--- a/src/env/functions.cpp
+++ b/src/env/functions.cpp
@@ -1,7 +1,10 @@
 #include "../../include/env/functions.hpp"
 #include "../../include/sexpr/BoolAtom.hpp"
+#include "../../include/sexpr/ClosureAtom.hpp"
 #include "../../include/sexpr/NilAtom.hpp"
 #include "../../include/sexpr/SExprs.hpp"
+#include "../../include/sexpr/SymAtom.hpp"
+#include "../sexpr/cast.cpp"
 #include <iostream>
 #include <memory>
 
@@ -113,28 +116,23 @@ shared_ptr<SExpr> lispCdr(shared_ptr<Env> env) {
 }
 
 shared_ptr<SExpr> lispIsNull(shared_ptr<Env> env) {
-  return make_shared<BoolAtom>(env->find("null?_oprand")->type ==
-                               SExpr::Type::NIL);
+  return make_shared<BoolAtom>(isa<NilAtom>(*env->find("null?_oprand")));
 }
 
 shared_ptr<SExpr> lispIsCons(shared_ptr<Env> env) {
-  return make_shared<BoolAtom>(env->find("cons?_oprand")->type ==
-                               SExpr::Type::SEXPRS);
+  return make_shared<BoolAtom>(isa<SExprs>(*env->find("cons?_oprand")));
 }
 
 shared_ptr<SExpr> lispIsSym(shared_ptr<Env> env) {
-  return make_shared<BoolAtom>(env->find("sym?_oprand")->type ==
-                               SExpr::Type::SYM);
+  return make_shared<BoolAtom>(isa<SymAtom>(*env->find("sym?_oprand")));
 }
 
 shared_ptr<SExpr> lispIsNum(shared_ptr<Env> env) {
-  return make_shared<BoolAtom>(env->find("num?_oprand")->type ==
-                               SExpr::Type::NUM);
+  return make_shared<BoolAtom>(isa<IntAtom>(*env->find("num?_oprand")));
 }
 
 shared_ptr<SExpr> lispIsProc(shared_ptr<Env> env) {
-  return make_shared<BoolAtom>(env->find("proc?_oprand")->type ==
-                               SExpr::Type::CLOSURE);
+  return make_shared<BoolAtom>(isa<ClosureAtom>(*env->find("proc?_oprand")));
 }
 
 shared_ptr<SExpr> lispIsEqv(shared_ptr<Env> env) {

--- a/src/env/functions.cpp
+++ b/src/env/functions.cpp
@@ -124,6 +124,5 @@ shared_ptr<SExpr> lispIsProc(shared_ptr<Env> env) {
 }
 
 shared_ptr<SExpr> lispIsEqv(shared_ptr<Env> env) {
-  return make_shared<BoolAtom>(
-      env->find("eq?_lhs")->equals(*env->find("eq?_rhs")));
+  return make_shared<BoolAtom>(*env->find("eq?_lhs") == *env->find("eq?_rhs"));
 }

--- a/src/env/functions.cpp
+++ b/src/env/functions.cpp
@@ -9,7 +9,6 @@
 #include <memory>
 
 using std::cout;
-using std::dynamic_pointer_cast;
 using std::endl;
 using std::make_shared;
 using std::shared_ptr;
@@ -25,82 +24,71 @@ shared_ptr<SExpr> lispDisplay(shared_ptr<Env> env) {
 }
 
 shared_ptr<SExpr> lispAbs(shared_ptr<Env> env) {
-  return make_shared<IntAtom>(
-      abs(dynamic_pointer_cast<IntAtom>(env->find("abs_oprand"))->val));
+  return make_shared<IntAtom>(abs(cast<IntAtom>(env->find("abs_oprand"))->val));
 }
 
 shared_ptr<SExpr> lispAdd(shared_ptr<Env> env) {
-  return make_shared<IntAtom>(
-      dynamic_pointer_cast<IntAtom>(env->find("add_lhs"))->val +
-      dynamic_pointer_cast<IntAtom>(env->find("add_rhs"))->val);
+  return make_shared<IntAtom>(cast<IntAtom>(env->find("add_lhs"))->val +
+                              cast<IntAtom>(env->find("add_rhs"))->val);
 }
 
 shared_ptr<SExpr> lispSub(shared_ptr<Env> env) {
-  return make_shared<IntAtom>(
-      dynamic_pointer_cast<IntAtom>(env->find("sub_lhs"))->val -
-      dynamic_pointer_cast<IntAtom>(env->find("sub_rhs"))->val);
+  return make_shared<IntAtom>(cast<IntAtom>(env->find("sub_lhs"))->val -
+                              cast<IntAtom>(env->find("sub_rhs"))->val);
 }
 
 shared_ptr<SExpr> lispMult(shared_ptr<Env> env) {
-  return make_shared<IntAtom>(
-      dynamic_pointer_cast<IntAtom>(env->find("mult_lhs"))->val *
-      dynamic_pointer_cast<IntAtom>(env->find("mult_rhs"))->val);
+  return make_shared<IntAtom>(cast<IntAtom>(env->find("mult_lhs"))->val *
+                              cast<IntAtom>(env->find("mult_rhs"))->val);
 }
 
 shared_ptr<SExpr> lispDiv(shared_ptr<Env> env) {
-  return make_shared<IntAtom>(
-      dynamic_pointer_cast<IntAtom>(env->find("div_lhs"))->val /
-      dynamic_pointer_cast<IntAtom>(env->find("div_rhs"))->val);
+  return make_shared<IntAtom>(cast<IntAtom>(env->find("div_lhs"))->val /
+                              cast<IntAtom>(env->find("div_rhs"))->val);
 }
 
 shared_ptr<SExpr> lispMod(shared_ptr<Env> env) {
-  return make_shared<IntAtom>(
-      dynamic_pointer_cast<IntAtom>(env->find("mod_lhs"))->val %
-      dynamic_pointer_cast<IntAtom>(env->find("mod_rhs"))->val);
+  return make_shared<IntAtom>(cast<IntAtom>(env->find("mod_lhs"))->val %
+                              cast<IntAtom>(env->find("mod_rhs"))->val);
 }
 
 shared_ptr<SExpr> lispEq(shared_ptr<Env> env) {
-  return make_shared<BoolAtom>(
-      (dynamic_pointer_cast<IntAtom>(env->find("eq_lhs"))->val ==
-       dynamic_pointer_cast<IntAtom>(env->find("eq_rhs"))->val));
+  return make_shared<BoolAtom>((cast<IntAtom>(env->find("eq_lhs"))->val ==
+                                cast<IntAtom>(env->find("eq_rhs"))->val));
 }
 
 shared_ptr<SExpr> lispGt(shared_ptr<Env> env) {
-  return make_shared<BoolAtom>(
-      (dynamic_pointer_cast<IntAtom>(env->find("gt_lhs"))->val >
-       dynamic_pointer_cast<IntAtom>(env->find("gt_rhs"))->val));
+  return make_shared<BoolAtom>((cast<IntAtom>(env->find("gt_lhs"))->val >
+                                cast<IntAtom>(env->find("gt_rhs"))->val));
 }
 
 shared_ptr<SExpr> lispGteq(shared_ptr<Env> env) {
-  return make_shared<BoolAtom>(
-      (dynamic_pointer_cast<IntAtom>(env->find("gteq_lhs"))->val >=
-       dynamic_pointer_cast<IntAtom>(env->find("gteq_rhs"))->val));
+  return make_shared<BoolAtom>((cast<IntAtom>(env->find("gteq_lhs"))->val >=
+                                cast<IntAtom>(env->find("gteq_rhs"))->val));
 }
 
 shared_ptr<SExpr> lispLt(shared_ptr<Env> env) {
-  return make_shared<BoolAtom>(
-      (dynamic_pointer_cast<IntAtom>(env->find("lt_lhs"))->val <
-       dynamic_pointer_cast<IntAtom>(env->find("lt_rhs"))->val));
+  return make_shared<BoolAtom>((cast<IntAtom>(env->find("lt_lhs"))->val <
+                                cast<IntAtom>(env->find("lt_rhs"))->val));
 }
 
 shared_ptr<SExpr> lispLteq(shared_ptr<Env> env) {
-  return make_shared<BoolAtom>(
-      (dynamic_pointer_cast<IntAtom>(env->find("lteq_lhs"))->val <=
-       dynamic_pointer_cast<IntAtom>(env->find("lteq_rhs"))->val));
+  return make_shared<BoolAtom>((cast<IntAtom>(env->find("lteq_lhs"))->val <=
+                                cast<IntAtom>(env->find("lteq_rhs"))->val));
 }
 
 shared_ptr<SExpr> lispNot(shared_ptr<Env> env) {
-  return make_shared<BoolAtom>(!BoolAtom::cast(env->find("not_oprand")));
+  return make_shared<BoolAtom>(!BoolAtom::toBool(env->find("not_oprand")));
 }
 
 shared_ptr<SExpr> lispAnd(shared_ptr<Env> env) {
-  return make_shared<BoolAtom>(BoolAtom::cast(env->find("and_lhs")) &&
-                               BoolAtom::cast(env->find("and_rhs")));
+  return make_shared<BoolAtom>(BoolAtom::toBool(env->find("and_lhs")) &&
+                               BoolAtom::toBool(env->find("and_rhs")));
 }
 
 shared_ptr<SExpr> lispOr(shared_ptr<Env> env) {
-  return make_shared<BoolAtom>(BoolAtom::cast(env->find("or_lhs")) ||
-                               BoolAtom::cast(env->find("or_rhs")));
+  return make_shared<BoolAtom>(BoolAtom::toBool(env->find("or_lhs")) ||
+                               BoolAtom::toBool(env->find("or_rhs")));
 }
 
 shared_ptr<SExpr> lispCons(shared_ptr<Env> env) {
@@ -108,11 +96,11 @@ shared_ptr<SExpr> lispCons(shared_ptr<Env> env) {
 }
 
 shared_ptr<SExpr> lispCar(shared_ptr<Env> env) {
-  return dynamic_pointer_cast<SExprs>(env->find("car_oprand"))->first;
+  return cast<SExprs>(env->find("car_oprand"))->first;
 }
 
 shared_ptr<SExpr> lispCdr(shared_ptr<Env> env) {
-  return dynamic_pointer_cast<SExprs>(env->find("cdr_oprand"))->rest;
+  return cast<SExprs>(env->find("cdr_oprand"))->rest;
 }
 
 shared_ptr<SExpr> lispIsNull(shared_ptr<Env> env) {

--- a/src/repl/EvalException.cpp
+++ b/src/repl/EvalException.cpp
@@ -1,0 +1,18 @@
+#include "../../include/repl/EvalException.hpp"
+#include <memory>
+#include <string>
+
+using std::shared_ptr;
+using std::string;
+
+EvalException::EvalException(const string &msg) : _msg(msg) {}
+
+const char *EvalException::what() const noexcept { return _msg.c_str(); }
+
+void EvalException::pushStackTrace(const shared_ptr<SExpr> stack) {
+  stackTrace.push_back(stack);
+}
+
+const vector<const shared_ptr<SExpr>> &EvalException::getStackTrace() const {
+  return stackTrace;
+}

--- a/src/repl/except/EvalException.cpp
+++ b/src/repl/except/EvalException.cpp
@@ -1,4 +1,4 @@
-#include "../../include/repl/EvalException.hpp"
+#include "../../../include/repl/except/EvalException.hpp"
 #include <memory>
 #include <string>
 

--- a/src/repl/except/EvalException.cpp
+++ b/src/repl/except/EvalException.cpp
@@ -9,10 +9,10 @@ EvalException::EvalException(const string &msg) : _msg(msg) {}
 
 const char *EvalException::what() const noexcept { return _msg.c_str(); }
 
-void EvalException::pushStackTrace(const shared_ptr<SExpr> stack) {
+void EvalException::pushStackTrace(shared_ptr<SExpr> stack) {
   stackTrace.push_back(stack);
 }
 
-const vector<const shared_ptr<SExpr>> &EvalException::getStackTrace() const {
+const vector<shared_ptr<SExpr>> &EvalException::getStackTrace() const {
   return stackTrace;
 }

--- a/src/repl/repl.cpp
+++ b/src/repl/repl.cpp
@@ -82,8 +82,7 @@ shared_ptr<SExpr> parse(vector<string> tokens) {
   return parse(it);
 }
 
-shared_ptr<SExpr> eval(shared_ptr<SExpr> sExpr,
-                       shared_ptr<Env> env) throw(EvalException) {
+shared_ptr<SExpr> eval(shared_ptr<SExpr> sExpr, shared_ptr<Env> env) {
   try {
     if (isa<NilAtom>(*sExpr) || isa<IntAtom>(*sExpr) || isa<BoolAtom>(*sExpr)) {
       return sExpr;

--- a/src/repl/repl.cpp
+++ b/src/repl/repl.cpp
@@ -1,6 +1,7 @@
 #include "../../include/repl/repl.hpp"
 #include "../../include/env/Env.hpp"
 #include "../../include/env/functions.hpp"
+#include "../../include/repl/EvalException.hpp"
 #include "../../include/sexpr/Atom.hpp"
 #include "../../include/sexpr/BoolAtom.hpp"
 #include "../../include/sexpr/ClosureAtom.hpp"
@@ -17,6 +18,7 @@
 #include <vector>
 
 using std::all_of;
+using std::cerr;
 using std::cin;
 using std::cout;
 using std::dynamic_pointer_cast;
@@ -80,54 +82,61 @@ shared_ptr<SExpr> parse(vector<string> tokens) {
   return parse(it);
 }
 
-shared_ptr<SExpr> eval(shared_ptr<SExpr> sExpr, shared_ptr<Env> env) {
-  if (isa<NilAtom>(*sExpr) || isa<IntAtom>(*sExpr) || isa<BoolAtom>(*sExpr)) {
-    return sExpr;
-  } else if (isa<SymAtom>(*sExpr)) {
-    return env->find(dynamic_pointer_cast<SymAtom>(sExpr)->val);
-  }
-  shared_ptr<SExprs> sExprs = dynamic_pointer_cast<SExprs>(sExpr);
-  shared_ptr<SymAtom> sym = dynamic_pointer_cast<SymAtom>(sExprs->first);
-  if (sym && sym->val == "define") {
-    sExprs = dynamic_pointer_cast<SExprs>(sExprs->rest);
-    string name = dynamic_pointer_cast<SymAtom>(sExprs->first)->val;
-    shared_ptr<SExpr> val =
-        eval(dynamic_pointer_cast<SExprs>(sExprs->rest)->first, env);
-    env->symTable.insert(make_pair(name, val));
-    return val;
-  } else if (sym && sym->val == "set!") {
-    sExprs = dynamic_pointer_cast<SExprs>(sExprs->rest);
-    string name = dynamic_pointer_cast<SymAtom>(sExprs->first)->val;
-    shared_ptr<SExpr> val =
-        eval(dynamic_pointer_cast<SExprs>(sExprs->rest)->first, env);
-    env->set(name, val);
-    return val;
-  } else if (sym && sym->val == "quote") {
-    sExprs = dynamic_pointer_cast<SExprs>(sExprs->rest);
-    return sExprs->first;
-  } else if (sym && sym->val == "if") {
-    sExprs = dynamic_pointer_cast<SExprs>(sExprs->rest);
-    shared_ptr<BoolAtom> test =
-        std::make_shared<BoolAtom>(eval(sExprs->first, env));
-    shared_ptr<SExpr> conseq =
-        dynamic_pointer_cast<SExprs>(sExprs->rest)->first;
-    shared_ptr<SExpr> alt =
-        dynamic_pointer_cast<SExprs>(
-            dynamic_pointer_cast<SExprs>(sExprs->rest)->rest)
-            ->first;
-    return (test->val) ? eval(conseq, env) : eval(alt, env);
-  } else if (sym && sym->val == "lambda") {
-    sExprs = dynamic_pointer_cast<SExprs>(sExprs->rest);
-    shared_ptr<SExpr> argNames = dynamic_pointer_cast<SExpr>(sExprs->first);
-    shared_ptr<SExpr> body = dynamic_pointer_cast<SExpr>(
-        dynamic_pointer_cast<SExprs>(sExprs->rest)->first);
+shared_ptr<SExpr> eval(shared_ptr<SExpr> sExpr,
+                       shared_ptr<Env> env) throw(EvalException) {
+  try {
+    if (isa<NilAtom>(*sExpr) || isa<IntAtom>(*sExpr) || isa<BoolAtom>(*sExpr)) {
+      return sExpr;
+    } else if (isa<SymAtom>(*sExpr)) {
+      return env->find(dynamic_pointer_cast<SymAtom>(sExpr)->val);
+    }
+    shared_ptr<SExprs> sExprs = dynamic_pointer_cast<SExprs>(sExpr);
+    shared_ptr<SymAtom> sym = dynamic_pointer_cast<SymAtom>(sExprs->first);
+    if (sym && sym->val == "define") {
+      sExprs = dynamic_pointer_cast<SExprs>(sExprs->rest);
+      string name = dynamic_pointer_cast<SymAtom>(sExprs->first)->val;
+      shared_ptr<SExpr> val =
+          eval(dynamic_pointer_cast<SExprs>(sExprs->rest)->first, env);
+      env->symTable.insert(make_pair(name, val));
+      return val;
+    } else if (sym && sym->val == "set!") {
+      sExprs = dynamic_pointer_cast<SExprs>(sExprs->rest);
+      string name = dynamic_pointer_cast<SymAtom>(sExprs->first)->val;
+      shared_ptr<SExpr> val =
+          eval(dynamic_pointer_cast<SExprs>(sExprs->rest)->first, env);
+      env->set(name, val);
+      return val;
+    } else if (sym && sym->val == "quote") {
+      sExprs = dynamic_pointer_cast<SExprs>(sExprs->rest);
+      return sExprs->first;
+    } else if (sym && sym->val == "if") {
+      sExprs = dynamic_pointer_cast<SExprs>(sExprs->rest);
+      shared_ptr<BoolAtom> test =
+          std::make_shared<BoolAtom>(eval(sExprs->first, env));
+      shared_ptr<SExpr> conseq =
+          dynamic_pointer_cast<SExprs>(sExprs->rest)->first;
+      shared_ptr<SExpr> alt =
+          dynamic_pointer_cast<SExprs>(
+              dynamic_pointer_cast<SExprs>(sExprs->rest)->rest)
+              ->first;
+      return (test->val) ? eval(conseq, env) : eval(alt, env);
+    } else if (sym && sym->val == "lambda") {
+      sExprs = dynamic_pointer_cast<SExprs>(sExprs->rest);
+      shared_ptr<SExpr> argNames = dynamic_pointer_cast<SExpr>(sExprs->first);
+      shared_ptr<SExpr> body = dynamic_pointer_cast<SExpr>(
+          dynamic_pointer_cast<SExprs>(sExprs->rest)->first);
 
-    return make_shared<ClosureAtom>(
-        [body](shared_ptr<Env> env) { return eval(body, env); }, env, argNames);
+      return make_shared<ClosureAtom>(
+          [body](shared_ptr<Env> env) { return eval(body, env); }, env,
+          argNames);
+    }
+    shared_ptr<ClosureAtom> closure =
+        dynamic_pointer_cast<ClosureAtom>(eval(sExprs->first, env));
+    return (*closure)(sExprs->rest, env);
+  } catch (EvalException ee) {
+    ee.pushStackTrace(sExpr);
+    throw ee;
   }
-  shared_ptr<ClosureAtom> closure =
-      dynamic_pointer_cast<ClosureAtom>(eval(sExprs->first, env));
-  return (*closure)(sExprs->rest, env);
 }
 
 void repl() {
@@ -138,8 +147,16 @@ void repl() {
     cout << "lisp> ";
     string input;
     getline(cin, input);
-    if (!std::all_of(input.begin(), input.end(), isspace)) {
-      cout << *eval(parse(tokenize(input)), env) << endl;
+    if (!all_of(input.begin(), input.end(), isspace)) {
+      try {
+        cout << *eval(parse(tokenize(input)), env) << endl;
+      } catch (EvalException ee) {
+        cerr << "Error: " << ee.what() << endl;
+        cerr << "Eval stack:" << endl;
+        for (auto it : ee.getStackTrace()) {
+          cerr << "=> " << *it << endl;
+        }
+      }
     }
   }
 }

--- a/src/repl/repl.cpp
+++ b/src/repl/repl.cpp
@@ -145,11 +145,12 @@ void repl() {
       try {
         cout << *eval(parse(tokenize(input)), env) << endl;
       } catch (EvalException ee) {
-        cerr << "Error: " << ee.what() << endl;
+        cerr << "Error: " << ee.what() << endl << endl;
         cerr << "Eval stack:" << endl;
         for (auto it : ee.getStackTrace()) {
           cerr << "=> " << *it << endl;
         }
+        cerr << endl;
       }
     }
   }

--- a/src/repl/repl.cpp
+++ b/src/repl/repl.cpp
@@ -1,7 +1,7 @@
 #include "../../include/repl/repl.hpp"
 #include "../../include/env/Env.hpp"
 #include "../../include/env/functions.hpp"
-#include "../../include/repl/EvalException.hpp"
+#include "../../include/repl/except/EvalException.hpp"
 #include "../../include/sexpr/Atom.hpp"
 #include "../../include/sexpr/BoolAtom.hpp"
 #include "../../include/sexpr/ClosureAtom.hpp"

--- a/src/repl/repl.cpp
+++ b/src/repl/repl.cpp
@@ -21,7 +21,6 @@ using std::all_of;
 using std::cerr;
 using std::cin;
 using std::cout;
-using std::dynamic_pointer_cast;
 using std::endl;
 using std::getline;
 using std::make_pair;
@@ -87,50 +86,46 @@ shared_ptr<SExpr> eval(shared_ptr<SExpr> sExpr, shared_ptr<Env> env) {
     if (isa<NilAtom>(*sExpr) || isa<IntAtom>(*sExpr) || isa<BoolAtom>(*sExpr)) {
       return sExpr;
     } else if (isa<SymAtom>(*sExpr)) {
-      return env->find(dynamic_pointer_cast<SymAtom>(sExpr)->val);
+      return env->find(cast<SymAtom>(sExpr)->val);
     }
-    shared_ptr<SExprs> sExprs = dynamic_pointer_cast<SExprs>(sExpr);
-    shared_ptr<SymAtom> sym = dynamic_pointer_cast<SymAtom>(sExprs->first);
-    if (sym && sym->val == "define") {
-      sExprs = dynamic_pointer_cast<SExprs>(sExprs->rest);
-      string name = dynamic_pointer_cast<SymAtom>(sExprs->first)->val;
-      shared_ptr<SExpr> val =
-          eval(dynamic_pointer_cast<SExprs>(sExprs->rest)->first, env);
-      env->symTable.insert(make_pair(name, val));
-      return val;
-    } else if (sym && sym->val == "set!") {
-      sExprs = dynamic_pointer_cast<SExprs>(sExprs->rest);
-      string name = dynamic_pointer_cast<SymAtom>(sExprs->first)->val;
-      shared_ptr<SExpr> val =
-          eval(dynamic_pointer_cast<SExprs>(sExprs->rest)->first, env);
-      env->set(name, val);
-      return val;
-    } else if (sym && sym->val == "quote") {
-      sExprs = dynamic_pointer_cast<SExprs>(sExprs->rest);
-      return sExprs->first;
-    } else if (sym && sym->val == "if") {
-      sExprs = dynamic_pointer_cast<SExprs>(sExprs->rest);
-      shared_ptr<BoolAtom> test =
-          std::make_shared<BoolAtom>(eval(sExprs->first, env));
-      shared_ptr<SExpr> conseq =
-          dynamic_pointer_cast<SExprs>(sExprs->rest)->first;
-      shared_ptr<SExpr> alt =
-          dynamic_pointer_cast<SExprs>(
-              dynamic_pointer_cast<SExprs>(sExprs->rest)->rest)
-              ->first;
-      return (test->val) ? eval(conseq, env) : eval(alt, env);
-    } else if (sym && sym->val == "lambda") {
-      sExprs = dynamic_pointer_cast<SExprs>(sExprs->rest);
-      shared_ptr<SExpr> argNames = dynamic_pointer_cast<SExpr>(sExprs->first);
-      shared_ptr<SExpr> body = dynamic_pointer_cast<SExpr>(
-          dynamic_pointer_cast<SExprs>(sExprs->rest)->first);
+    shared_ptr<SExprs> sExprs = cast<SExprs>(sExpr);
+    if (isa<SymAtom>(*sExprs->first)) {
+      shared_ptr<SymAtom> sym = cast<SymAtom>(sExprs->first);
+      if (sym->val == "define") {
+        sExprs = cast<SExprs>(sExprs->rest);
+        string name = cast<SymAtom>(sExprs->first)->val;
+        shared_ptr<SExpr> val = eval(cast<SExprs>(sExprs->rest)->first, env);
+        env->symTable.insert(make_pair(name, val));
+        return val;
+      } else if (sym->val == "set!") {
+        sExprs = cast<SExprs>(sExprs->rest);
+        string name = cast<SymAtom>(sExprs->first)->val;
+        shared_ptr<SExpr> val = eval(cast<SExprs>(sExprs->rest)->first, env);
+        env->set(name, val);
+        return val;
+      } else if (sym->val == "quote") {
+        sExprs = cast<SExprs>(sExprs->rest);
+        return sExprs->first;
+      } else if (sym->val == "if") {
+        sExprs = cast<SExprs>(sExprs->rest);
+        shared_ptr<BoolAtom> test =
+            std::make_shared<BoolAtom>(eval(sExprs->first, env));
+        shared_ptr<SExpr> conseq = cast<SExprs>(sExprs->rest)->first;
+        shared_ptr<SExpr> alt =
+            cast<SExprs>(cast<SExprs>(sExprs->rest)->rest)->first;
+        return (test->val) ? eval(conseq, env) : eval(alt, env);
+      } else if (sym->val == "lambda") {
+        sExprs = cast<SExprs>(sExprs->rest);
+        shared_ptr<SExpr> argNames = sExprs->first;
+        shared_ptr<SExpr> body = cast<SExprs>(sExprs->rest)->first;
 
-      return make_shared<ClosureAtom>(
-          [body](shared_ptr<Env> env) { return eval(body, env); }, env,
-          argNames);
+        return make_shared<ClosureAtom>(
+            [body](shared_ptr<Env> env) { return eval(body, env); }, env,
+            argNames);
+      }
     }
     shared_ptr<ClosureAtom> closure =
-        dynamic_pointer_cast<ClosureAtom>(eval(sExprs->first, env));
+        cast<ClosureAtom>(eval(sExprs->first, env));
     return (*closure)(sExprs->rest, env);
   } catch (EvalException ee) {
     ee.pushStackTrace(sExpr);

--- a/src/repl/repl.cpp
+++ b/src/repl/repl.cpp
@@ -8,6 +8,7 @@
 #include "../../include/sexpr/NilAtom.hpp"
 #include "../../include/sexpr/SExpr.hpp"
 #include "../../include/sexpr/SymAtom.hpp"
+#include "../sexpr/cast.cpp"
 #include <algorithm>
 #include <iostream>
 #include <memory>
@@ -80,10 +81,9 @@ shared_ptr<SExpr> parse(vector<string> tokens) {
 }
 
 shared_ptr<SExpr> eval(shared_ptr<SExpr> sExpr, shared_ptr<Env> env) {
-  if (sExpr->type == SExpr::Type::NIL || sExpr->type == SExpr::Type::NUM ||
-      sExpr->type == SExpr::Type::BOOL) {
+  if (isa<NilAtom>(*sExpr) || isa<IntAtom>(*sExpr) || isa<BoolAtom>(*sExpr)) {
     return sExpr;
-  } else if (sExpr->type == SExpr::Type::SYM) {
+  } else if (isa<SymAtom>(*sExpr)) {
     return env->find(dynamic_pointer_cast<SymAtom>(sExpr)->val);
   }
   shared_ptr<SExprs> sExprs = dynamic_pointer_cast<SExprs>(sExpr);

--- a/src/sexpr/BoolAtom.cpp
+++ b/src/sexpr/BoolAtom.cpp
@@ -3,13 +3,12 @@
 #include <memory>
 #include <string>
 
-using std::dynamic_pointer_cast;
 using std::shared_ptr;
 using std::string;
 
-bool BoolAtom::cast(const shared_ptr<SExpr> sExpr) {
+bool BoolAtom::toBool(shared_ptr<SExpr> sExpr) {
   if (isa<BoolAtom>(*sExpr)) {
-    return dynamic_pointer_cast<BoolAtom>(sExpr)->val;
+    return cast<BoolAtom>(sExpr)->val;
   }
   return true;
 }
@@ -17,7 +16,7 @@ bool BoolAtom::cast(const shared_ptr<SExpr> sExpr) {
 BoolAtom::BoolAtom(const bool val) : Atom(SExpr::Type::BOOL), val(val) {}
 
 BoolAtom::BoolAtom(const shared_ptr<SExpr> sExpr)
-    : Atom(SExpr::Type::BOOL), val(cast(sExpr)) {}
+    : Atom(SExpr::Type::BOOL), val(toBool(sExpr)) {}
 
 string BoolAtom::toString() const { return (val) ? "#t" : "#f"; }
 
@@ -28,6 +27,4 @@ bool BoolAtom::equals(const SExpr &other) const {
   return val == dynamic_cast<const BoolAtom &>(other).val;
 }
 
-bool BoolAtom::classOf(const SExpr &sExpr) {
-  return sExpr.type == SExpr::Type::BOOL;
-}
+bool BoolAtom::classOf(SExpr &sExpr) { return sExpr.type == SExpr::Type::BOOL; }

--- a/src/sexpr/BoolAtom.cpp
+++ b/src/sexpr/BoolAtom.cpp
@@ -30,3 +30,5 @@ bool BoolAtom::equals(const SExpr &other) const {
 bool BoolAtom::classOf(const SExpr &sExpr) {
   return sExpr.type == SExpr::Type::BOOL;
 }
+
+const string BoolAtom::typeName = "Boolean";

--- a/src/sexpr/BoolAtom.cpp
+++ b/src/sexpr/BoolAtom.cpp
@@ -21,10 +21,12 @@ BoolAtom::BoolAtom(const shared_ptr<SExpr> sExpr)
 string BoolAtom::toString() const { return (val) ? "#t" : "#f"; }
 
 bool BoolAtom::equals(const SExpr &other) const {
-  if (other.type != SExpr::Type::BOOL) {
-    return false;
+  if (isa<BoolAtom>(other)) {
+    return val == dynamic_cast<const BoolAtom &>(other).val;
   }
-  return val == dynamic_cast<const BoolAtom &>(other).val;
+  return false;
 }
 
-bool BoolAtom::classOf(SExpr &sExpr) { return sExpr.type == SExpr::Type::BOOL; }
+bool BoolAtom::classOf(const SExpr &sExpr) {
+  return sExpr.type == SExpr::Type::BOOL;
+}

--- a/src/sexpr/BoolAtom.cpp
+++ b/src/sexpr/BoolAtom.cpp
@@ -1,4 +1,5 @@
 #include "../../include/sexpr/BoolAtom.hpp"
+#include "cast.cpp"
 #include <memory>
 #include <string>
 
@@ -7,7 +8,7 @@ using std::shared_ptr;
 using std::string;
 
 bool BoolAtom::cast(const shared_ptr<SExpr> sExpr) {
-  if (sExpr->type == SExpr::Type::BOOL) {
+  if (isa<BoolAtom>(*sExpr)) {
     return dynamic_pointer_cast<BoolAtom>(sExpr)->val;
   }
   return true;
@@ -25,4 +26,8 @@ bool BoolAtom::equals(const SExpr &other) const {
     return false;
   }
   return val == dynamic_cast<const BoolAtom &>(other).val;
+}
+
+bool BoolAtom::classOf(const SExpr &sExpr) {
+  return sExpr.type == SExpr::Type::BOOL;
 }

--- a/src/sexpr/ClosureAtom.cpp
+++ b/src/sexpr/ClosureAtom.cpp
@@ -5,7 +5,6 @@
 #include <memory>
 #include <string>
 
-using std::dynamic_pointer_cast;
 using std::make_shared;
 using std::shared_ptr;
 using std::string;
@@ -23,16 +22,19 @@ shared_ptr<Env> ClosureAtom::bindArgs(shared_ptr<SExpr> args,
   }
   shared_ptr<SExpr> argVals = evalArgs(args, curEnv);
   if (isa<SExprs>(*argNames)) {
-    shared_ptr<SExprs> argNamesIter = dynamic_pointer_cast<SExprs>(argNames);
-    shared_ptr<SExprs> argValsIter = dynamic_pointer_cast<SExprs>(argVals);
-    while (argNamesIter) {
-      string argName = dynamic_pointer_cast<SymAtom>(argNamesIter->first)->val;
+    shared_ptr<SExprs> argNamesIter = cast<SExprs>(argNames);
+    shared_ptr<SExprs> argValsIter = cast<SExprs>(argVals);
+    while (true) {
+      string argName = cast<SymAtom>(argNamesIter->first)->val;
       env->symTable[argName] = argValsIter->first;
-      argNamesIter = dynamic_pointer_cast<SExprs>(argNamesIter->rest);
-      argValsIter = dynamic_pointer_cast<SExprs>(argValsIter->rest);
+      if (isa<NilAtom>(*argNamesIter->rest)) {
+        break;
+      }
+      argNamesIter = cast<SExprs>(argNamesIter->rest);
+      argValsIter = cast<SExprs>(argValsIter->rest);
     }
   } else {
-    string argName = dynamic_pointer_cast<SymAtom>(argNames)->val;
+    string argName = cast<SymAtom>(argNames)->val;
     env->symTable[argName] = evalArgs(args, curEnv);
   }
   return env;
@@ -43,7 +45,7 @@ std::shared_ptr<SExpr> ClosureAtom::evalArgs(shared_ptr<SExpr> args,
   if (isa<NilAtom>(*args)) {
     return make_shared<NilAtom>();
   }
-  shared_ptr<SExprs> sExprs = dynamic_pointer_cast<SExprs>(args);
+  shared_ptr<SExprs> sExprs = cast<SExprs>(args);
   return make_shared<SExprs>(eval(sExprs->first, curEnv),
                              evalArgs(sExprs->rest, curEnv));
 }
@@ -62,6 +64,6 @@ bool ClosureAtom::equals(const SExpr &other) const {
   return &proc == &dynamic_cast<const ClosureAtom &>(other).proc;
 }
 
-bool ClosureAtom::classOf(const SExpr &sExpr) {
+bool ClosureAtom::classOf(SExpr &sExpr) {
   return sExpr.type == SExpr::Type::CLOSURE;
 }

--- a/src/sexpr/ClosureAtom.cpp
+++ b/src/sexpr/ClosureAtom.cpp
@@ -59,8 +59,8 @@ std::shared_ptr<SExpr> ClosureAtom::evalArgs(shared_ptr<SExpr> args,
 void ClosureAtom::handleArgMismatch(shared_ptr<SExpr> argNames,
                                     shared_ptr<SExpr> argVals) {
   stringstream ss;
-  ss << "Invalid number of arguments, expecting: " << *argNames
-     << " got: " << *argVals;
+  ss << "Invalid number of arguments. Expected \"" << *argNames
+     << "\", but got \"" << *argVals << "\".";
   throw EvalException(ss.str());
 }
 
@@ -81,3 +81,5 @@ bool ClosureAtom::equals(const SExpr &other) const {
 bool ClosureAtom::classOf(const SExpr &sExpr) {
   return sExpr.type == SExpr::Type::CLOSURE;
 }
+
+const string ClosureAtom::typeName = "<closure>";

--- a/src/sexpr/ClosureAtom.cpp
+++ b/src/sexpr/ClosureAtom.cpp
@@ -1,5 +1,5 @@
 #include "../../include/sexpr/ClosureAtom.hpp"
-#include "../../include/repl/EvalException.hpp"
+#include "../../include/repl/except/EvalException.hpp"
 #include "../../include/repl/repl.hpp"
 #include "../../include/sexpr/NilAtom.hpp"
 #include "cast.cpp"

--- a/src/sexpr/ClosureAtom.cpp
+++ b/src/sexpr/ClosureAtom.cpp
@@ -1,6 +1,7 @@
 #include "../../include/sexpr/ClosureAtom.hpp"
 #include "../../include/repl/repl.hpp"
 #include "../../include/sexpr/NilAtom.hpp"
+#include "cast.cpp"
 #include <memory>
 #include <string>
 
@@ -17,11 +18,11 @@ ClosureAtom::ClosureAtom(Proc proc, const shared_ptr<Env> outerEnv,
 shared_ptr<Env> ClosureAtom::bindArgs(shared_ptr<SExpr> args,
                                       shared_ptr<Env> curEnv) {
   shared_ptr<Env> env = std::make_shared<Env>(outerEnv);
-  if (argNames->type == SExpr::Type::NIL) {
+  if (isa<NilAtom>(*argNames)) {
     return env;
   }
   shared_ptr<SExpr> argVals = evalArgs(args, curEnv);
-  if (argNames->type == SExpr::Type::SEXPRS) {
+  if (isa<SExprs>(*argNames)) {
     shared_ptr<SExprs> argNamesIter = dynamic_pointer_cast<SExprs>(argNames);
     shared_ptr<SExprs> argValsIter = dynamic_pointer_cast<SExprs>(argVals);
     while (argNamesIter) {
@@ -39,7 +40,7 @@ shared_ptr<Env> ClosureAtom::bindArgs(shared_ptr<SExpr> args,
 
 std::shared_ptr<SExpr> ClosureAtom::evalArgs(shared_ptr<SExpr> args,
                                              shared_ptr<Env> curEnv) {
-  if (args->type == SExpr::Type::NIL) {
+  if (isa<NilAtom>(*args)) {
     return make_shared<NilAtom>();
   }
   shared_ptr<SExprs> sExprs = dynamic_pointer_cast<SExprs>(args);
@@ -59,4 +60,8 @@ bool ClosureAtom::equals(const SExpr &other) const {
     return false;
   }
   return &proc == &dynamic_cast<const ClosureAtom &>(other).proc;
+}
+
+bool ClosureAtom::classOf(const SExpr &sExpr) {
+  return sExpr.type == SExpr::Type::CLOSURE;
 }

--- a/src/sexpr/ClosureAtom.cpp
+++ b/src/sexpr/ClosureAtom.cpp
@@ -58,12 +58,12 @@ shared_ptr<SExpr> ClosureAtom::operator()(shared_ptr<SExpr> args,
 string ClosureAtom::toString() const { return "<closure>"; }
 
 bool ClosureAtom::equals(const SExpr &other) const {
-  if (other.type != SExpr::Type::CLOSURE) {
-    return false;
+  if (isa<ClosureAtom>(other)) {
+    return &proc == &dynamic_cast<const ClosureAtom &>(other).proc;
   }
-  return &proc == &dynamic_cast<const ClosureAtom &>(other).proc;
+  return false;
 }
 
-bool ClosureAtom::classOf(SExpr &sExpr) {
+bool ClosureAtom::classOf(const SExpr &sExpr) {
   return sExpr.type == SExpr::Type::CLOSURE;
 }

--- a/src/sexpr/IntAtom.cpp
+++ b/src/sexpr/IntAtom.cpp
@@ -19,3 +19,5 @@ bool IntAtom::equals(const SExpr &other) const {
 bool IntAtom::classOf(const SExpr &sExpr) {
   return sExpr.type == SExpr::Type::NUM;
 }
+
+const string IntAtom::typeName = "Integer";

--- a/src/sexpr/IntAtom.cpp
+++ b/src/sexpr/IntAtom.cpp
@@ -15,6 +15,4 @@ bool IntAtom::equals(const SExpr &other) const {
   return val == dynamic_cast<const IntAtom &>(other).val;
 }
 
-bool IntAtom::classOf(const SExpr &sExpr) {
-  return sExpr.type == SExpr::Type::NUM;
-}
+bool IntAtom::classOf(SExpr &sExpr) { return sExpr.type == SExpr::Type::NUM; }

--- a/src/sexpr/IntAtom.cpp
+++ b/src/sexpr/IntAtom.cpp
@@ -1,4 +1,5 @@
 #include "../../include/sexpr/IntAtom.hpp"
+#include "cast.cpp"
 #include <string>
 
 using std::string;
@@ -9,10 +10,12 @@ IntAtom::IntAtom(const int val) : Atom(SExpr::Type::NUM), val(val) {}
 string IntAtom::toString() const { return to_string(val); }
 
 bool IntAtom::equals(const SExpr &other) const {
-  if (other.type != SExpr::Type::NUM) {
-    return false;
+  if (isa<IntAtom>(other)) {
+    return val == dynamic_cast<const IntAtom &>(other).val;
   }
-  return val == dynamic_cast<const IntAtom &>(other).val;
+  return false;
 }
 
-bool IntAtom::classOf(SExpr &sExpr) { return sExpr.type == SExpr::Type::NUM; }
+bool IntAtom::classOf(const SExpr &sExpr) {
+  return sExpr.type == SExpr::Type::NUM;
+}

--- a/src/sexpr/IntAtom.cpp
+++ b/src/sexpr/IntAtom.cpp
@@ -14,3 +14,7 @@ bool IntAtom::equals(const SExpr &other) const {
   }
   return val == dynamic_cast<const IntAtom &>(other).val;
 }
+
+bool IntAtom::classOf(const SExpr &sExpr) {
+  return sExpr.type == SExpr::Type::NUM;
+}

--- a/src/sexpr/NilAtom.cpp
+++ b/src/sexpr/NilAtom.cpp
@@ -10,8 +10,8 @@ NilAtom::NilAtom() : Atom(SExpr::Type::NIL) {}
 
 string NilAtom::toString() const { return "()"; }
 
-bool NilAtom::equals(const SExpr &other) const { return isa<NilAtom>(other); }
-
-bool NilAtom::classOf(const SExpr &sExpr) {
-  return sExpr.type == SExpr::Type::NIL;
+bool NilAtom::equals(const SExpr &other) const {
+  return other.type == SExpr::Type::NIL;
 }
+
+bool NilAtom::classOf(SExpr &sExpr) { return sExpr.type == SExpr::Type::NIL; }

--- a/src/sexpr/NilAtom.cpp
+++ b/src/sexpr/NilAtom.cpp
@@ -1,12 +1,17 @@
 #include "../../include/sexpr/NilAtom.hpp"
+#include "cast.cpp"
+#include <memory>
 #include <string>
 
+using std::shared_ptr;
 using std::string;
 
 NilAtom::NilAtom() : Atom(SExpr::Type::NIL) {}
 
 string NilAtom::toString() const { return "()"; }
 
-bool NilAtom::equals(const SExpr &other) const {
-  return other.type == SExpr::Type::NIL;
+bool NilAtom::equals(const SExpr &other) const { return isa<NilAtom>(other); }
+
+bool NilAtom::classOf(const SExpr &sExpr) {
+  return sExpr.type == SExpr::Type::NIL;
 }

--- a/src/sexpr/NilAtom.cpp
+++ b/src/sexpr/NilAtom.cpp
@@ -10,8 +10,8 @@ NilAtom::NilAtom() : Atom(SExpr::Type::NIL) {}
 
 string NilAtom::toString() const { return "()"; }
 
-bool NilAtom::equals(const SExpr &other) const {
-  return other.type == SExpr::Type::NIL;
-}
+bool NilAtom::equals(const SExpr &other) const { return isa<NilAtom>(other); }
 
-bool NilAtom::classOf(SExpr &sExpr) { return sExpr.type == SExpr::Type::NIL; }
+bool NilAtom::classOf(const SExpr &sExpr) {
+  return sExpr.type == SExpr::Type::NIL;
+}

--- a/src/sexpr/NilAtom.cpp
+++ b/src/sexpr/NilAtom.cpp
@@ -15,3 +15,5 @@ bool NilAtom::equals(const SExpr &other) const { return isa<NilAtom>(other); }
 bool NilAtom::classOf(const SExpr &sExpr) {
   return sExpr.type == SExpr::Type::NIL;
 }
+
+const string NilAtom::typeName = "()";

--- a/src/sexpr/SExpr.cpp
+++ b/src/sexpr/SExpr.cpp
@@ -8,7 +8,7 @@ using std::ostream;
 SExpr::SExpr(SExpr::Type type) : type(type) {}
 
 ostream &operator<<(ostream &o, const SExpr &sExpr) {
-  return o << (sExpr.type == SExpr::SEXPRS ? "(" : "") << sExpr.toString();
+  return o << (isa<SExprs>(sExpr) ? "(" : "") << sExpr.toString();
 }
 
 bool operator==(SExpr &lhs, SExpr &rhs) { return lhs.equals(rhs); }

--- a/src/sexpr/SExpr.cpp
+++ b/src/sexpr/SExpr.cpp
@@ -1,4 +1,6 @@
 #include "../../include/sexpr/SExpr.hpp"
+#include "../../include/sexpr/SExprs.hpp"
+#include "cast.cpp"
 #include <iostream>
 
 using std::ostream;
@@ -6,8 +8,7 @@ using std::ostream;
 SExpr::SExpr(SExpr::Type type) : type(type) {}
 
 ostream &operator<<(ostream &o, const SExpr &sExpr) {
-  return o << (sExpr.type == SExpr::Type::SEXPRS ? "(" : "")
-           << sExpr.toString();
+  return o << (isa<SExprs>(sExpr) ? "(" : "") << sExpr.toString();
 }
 
 bool operator==(SExpr &lhs, SExpr &rhs) { return lhs.equals(rhs); }

--- a/src/sexpr/SExpr.cpp
+++ b/src/sexpr/SExpr.cpp
@@ -8,7 +8,7 @@ using std::ostream;
 SExpr::SExpr(SExpr::Type type) : type(type) {}
 
 ostream &operator<<(ostream &o, const SExpr &sExpr) {
-  return o << (isa<SExprs>(sExpr) ? "(" : "") << sExpr.toString();
+  return o << (sExpr.type == SExpr::SEXPRS ? "(" : "") << sExpr.toString();
 }
 
 bool operator==(SExpr &lhs, SExpr &rhs) { return lhs.equals(rhs); }

--- a/src/sexpr/SExprs.cpp
+++ b/src/sexpr/SExprs.cpp
@@ -1,4 +1,6 @@
 #include "../../include/sexpr/SExprs.hpp"
+#include "../../include/sexpr/NilAtom.hpp"
+#include "cast.cpp"
 #include <memory>
 #include <string>
 
@@ -10,9 +12,9 @@ SExprs::SExprs(shared_ptr<SExpr> first, shared_ptr<SExpr> rest)
 
 string SExprs::toString() const {
   string str = "";
-  str += first->type == SExpr::Type::SEXPRS ? "(" : "";
+  str += isa<SExprs>(*first) ? "(" : "";
   str += first->toString();
-  str += rest->type == SExpr::Type::NIL ? ")" : " " + rest->toString();
+  str += isa<NilAtom>(*rest) ? ")" : " " + rest->toString();
   return str;
 }
 
@@ -22,4 +24,8 @@ bool SExprs::equals(const SExpr &other) const {
   }
   const SExprs &sExprs = dynamic_cast<const SExprs &>(other);
   return first->equals(*sExprs.first) && rest->equals(*sExprs.rest);
+}
+
+bool SExprs::classOf(const SExpr &sExpr) {
+  return sExpr.type == SExpr::Type::SEXPRS;
 }

--- a/src/sexpr/SExprs.cpp
+++ b/src/sexpr/SExprs.cpp
@@ -31,3 +31,5 @@ bool SExprs::equals(const SExpr &other) const {
 bool SExprs::classOf(const SExpr &sExpr) {
   return sExpr.type == SExpr::Type::SEXPRS;
 }
+
+const string SExprs::typeName = "One or more symbolic expressions";

--- a/src/sexpr/SExprs.cpp
+++ b/src/sexpr/SExprs.cpp
@@ -26,6 +26,4 @@ bool SExprs::equals(const SExpr &other) const {
   return first->equals(*sExprs.first) && rest->equals(*sExprs.rest);
 }
 
-bool SExprs::classOf(const SExpr &sExpr) {
-  return sExpr.type == SExpr::Type::SEXPRS;
-}
+bool SExprs::classOf(SExpr &sExpr) { return sExpr.type == SExpr::Type::SEXPRS; }

--- a/src/sexpr/SExprs.cpp
+++ b/src/sexpr/SExprs.cpp
@@ -19,11 +19,13 @@ string SExprs::toString() const {
 }
 
 bool SExprs::equals(const SExpr &other) const {
-  if (other.type != SExpr::Type::SEXPRS) {
-    return false;
+  if (isa<SExprs>(other)) {
+    const SExprs &sExprs = dynamic_cast<const SExprs &>(other);
+    return first->equals(*sExprs.first) && rest->equals(*sExprs.rest);
   }
-  const SExprs &sExprs = dynamic_cast<const SExprs &>(other);
-  return first->equals(*sExprs.first) && rest->equals(*sExprs.rest);
+  return false;
 }
 
-bool SExprs::classOf(SExpr &sExpr) { return sExpr.type == SExpr::Type::SEXPRS; }
+bool SExprs::classOf(const SExpr &sExpr) {
+  return sExpr.type == SExpr::Type::SEXPRS;
+}

--- a/src/sexpr/SExprs.cpp
+++ b/src/sexpr/SExprs.cpp
@@ -2,10 +2,12 @@
 #include "../../include/sexpr/NilAtom.hpp"
 #include "cast.cpp"
 #include <memory>
+#include <sstream>
 #include <string>
 
 using std::shared_ptr;
 using std::string;
+using std::stringstream;
 
 SExprs::SExprs(shared_ptr<SExpr> first, shared_ptr<SExpr> rest)
     : SExpr(SExpr::Type::SEXPRS), first(first), rest(rest) {}

--- a/src/sexpr/SymAtom.cpp
+++ b/src/sexpr/SymAtom.cpp
@@ -16,6 +16,4 @@ bool SymAtom::equals(const SExpr &other) const {
   return val == dynamic_cast<const SymAtom &>(other).val;
 }
 
-bool SymAtom::classOf(const SExpr &sExpr) {
-  return sExpr.type == SExpr::Type::SYM;
-}
+bool SymAtom::classOf(SExpr &sExpr) { return sExpr.type == SExpr::Type::SYM; }

--- a/src/sexpr/SymAtom.cpp
+++ b/src/sexpr/SymAtom.cpp
@@ -1,4 +1,5 @@
 #include "../../include/sexpr/SymAtom.hpp"
+#include "cast.cpp"
 #include <memory>
 #include <string>
 
@@ -10,10 +11,12 @@ SymAtom::SymAtom(string val) : Atom(SExpr::Type::SYM), val(val) {}
 string SymAtom::toString() const { return val; }
 
 bool SymAtom::equals(const SExpr &other) const {
-  if (other.type != SExpr::SYM) {
-    return false;
+  if (isa<SymAtom>(other)) {
+    return val == dynamic_cast<const SymAtom &>(other).val;
   }
-  return val == dynamic_cast<const SymAtom &>(other).val;
+  return false;
 }
 
-bool SymAtom::classOf(SExpr &sExpr) { return sExpr.type == SExpr::Type::SYM; }
+bool SymAtom::classOf(const SExpr &sExpr) {
+  return sExpr.type == SExpr::Type::SYM;
+}

--- a/src/sexpr/SymAtom.cpp
+++ b/src/sexpr/SymAtom.cpp
@@ -20,3 +20,5 @@ bool SymAtom::equals(const SExpr &other) const {
 bool SymAtom::classOf(const SExpr &sExpr) {
   return sExpr.type == SExpr::Type::SYM;
 }
+
+const string SymAtom::typeName = "Symbol";

--- a/src/sexpr/SymAtom.cpp
+++ b/src/sexpr/SymAtom.cpp
@@ -1,6 +1,8 @@
 #include "../../include/sexpr/SymAtom.hpp"
+#include <memory>
 #include <string>
 
+using std::shared_ptr;
 using std::string;
 
 SymAtom::SymAtom(string val) : Atom(SExpr::Type::SYM), val(val) {}
@@ -12,4 +14,8 @@ bool SymAtom::equals(const SExpr &other) const {
     return false;
   }
   return val == dynamic_cast<const SymAtom &>(other).val;
+}
+
+bool SymAtom::classOf(const SExpr &sExpr) {
+  return sExpr.type == SExpr::Type::SYM;
 }

--- a/src/sexpr/cast.cpp
+++ b/src/sexpr/cast.cpp
@@ -1,4 +1,4 @@
-#include "../../include/repl/EvalException.hpp"
+#include "../../include/repl/except/EvalException.hpp"
 #include <memory>
 #include <sstream>
 

--- a/src/sexpr/cast.cpp
+++ b/src/sexpr/cast.cpp
@@ -15,6 +15,7 @@ template <typename To, typename From> shared_ptr<To> cast(shared_ptr<From> f) {
     return dynamic_pointer_cast<To>(f);
   }
   stringstream ss;
-  ss << *f << " is not a " << typeid(To).name();
+  ss << "Mismatched types. Expected \"" << To::typeName << "\", but got \""
+     << *f << "\".";
   throw EvalException(ss.str());
 }

--- a/src/sexpr/cast.cpp
+++ b/src/sexpr/cast.cpp
@@ -1,0 +1,7 @@
+#include <memory>
+
+using std::shared_ptr;
+
+template <typename To, typename From> bool isa(const From &f) {
+  return To::classOf(f);
+}

--- a/src/sexpr/cast.cpp
+++ b/src/sexpr/cast.cpp
@@ -1,7 +1,5 @@
 #include <memory>
 
-using std::shared_ptr;
-
 template <typename To, typename From> bool isa(const From &f) {
   return To::classOf(f);
 }

--- a/src/sexpr/cast.cpp
+++ b/src/sexpr/cast.cpp
@@ -1,8 +1,10 @@
 #include "../../include/repl/EvalException.hpp"
 #include <memory>
+#include <sstream>
 
 using std::dynamic_pointer_cast;
 using std::shared_ptr;
+using std::stringstream;
 
 template <typename To, typename From> bool isa(From &f) {
   return To::classOf(f);
@@ -12,5 +14,7 @@ template <typename To, typename From> shared_ptr<To> cast(shared_ptr<From> f) {
   if (isa<To>(*f)) {
     return dynamic_pointer_cast<To>(f);
   }
-  throw EvalException(f->toString() + " is not a " + typeid(To).name());
+  stringstream ss;
+  ss << *f << " is not a " << typeid(To).name();
+  throw EvalException(ss.str());
 }

--- a/src/sexpr/cast.cpp
+++ b/src/sexpr/cast.cpp
@@ -1,5 +1,16 @@
+#include "../../include/repl/EvalException.hpp"
 #include <memory>
 
-template <typename To, typename From> bool isa(const From &f) {
+using std::dynamic_pointer_cast;
+using std::shared_ptr;
+
+template <typename To, typename From> bool isa(From &f) {
   return To::classOf(f);
+}
+
+template <typename To, typename From> shared_ptr<To> cast(shared_ptr<From> f) {
+  if (To::classOf(*f)) {
+    return dynamic_pointer_cast<To>(f);
+  }
+  throw EvalException(f->toString() + " is not a " + typeid(To).name());
 }

--- a/src/sexpr/cast.cpp
+++ b/src/sexpr/cast.cpp
@@ -9,7 +9,7 @@ template <typename To, typename From> bool isa(From &f) {
 }
 
 template <typename To, typename From> shared_ptr<To> cast(shared_ptr<From> f) {
-  if (To::classOf(*f)) {
+  if (isa<To>(*f)) {
     return dynamic_pointer_cast<To>(f);
   }
   throw EvalException(f->toString() + " is not a " + typeid(To).name());


### PR DESCRIPTION
Implement graceful error for:
- Undefined symbol
- Type mismatch
- Invalid number of arguments