### PR TITLE
GNU-readline integration

### DIFF
--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ TESTS = $(TESTDIR)/combine $(TESTDIR)/cons $(TESTDIR)/hof $(TESTDIR)/list \
 	$(TESTDIR)/string $(TESTDIR)/tailcall $(TESTDIR)/varargs
 
 $(OUTDIR)/lisp: $(OBJS) $(DEPS) $(OUTDIR)/main.o
-	$(CXX) $(CXXFLAGS) $(OBJS) $(OUTDIR)/main.o -o $(OUTDIR)/lisp
+	$(CXX) $(CXXFLAGS) $(OBJS) $(OUTDIR)/main.o -lreadline -o $(OUTDIR)/lisp
 
 $(OUTDIR)/main.o: $(SRCDIR)/main.cpp $(DEPS)
 	$(CXX) $(CXXFLAGS) -c $< -o $@

--- a/src/parse/parse.cpp
+++ b/src/parse/parse.cpp
@@ -152,27 +152,3 @@ void verifyLex(std::string &line, uint32_t &openParen, uint32_t &closedParen) {
     handleUnexpectedToken(tokens, tokens.begin() + 1);
   }
 }
-
-std::istream &getInput(std::istream &in, std::string &str, size_t &linesRead,
-                       std::string prompt, std::string wrap) {
-  uint32_t openParen = 0;
-  uint32_t closedParen = 0;
-  std::string line;
-  std::cout << prompt;
-  while (getline(in, line)) {
-    linesRead += 1;
-    line = std::regex_replace(
-        line, std::regex("(\\\\\"|\"(?:\\\\\"|[^\"])*\")|(;.*$)"), "$1");
-    if (str.empty() && line.empty()) {
-      std::cout << prompt;
-      continue;
-    }
-    verifyLex(line, openParen, closedParen);
-    str += line + " ";
-    if (openParen == closedParen) {
-      return in;
-    }
-    std::cout << wrap;
-  }
-  return in;
-}

--- a/src/parse/parse.hpp
+++ b/src/parse/parse.hpp
@@ -5,10 +5,8 @@
 #include <memory>
 #include <string>
 
-std::shared_ptr<SExpr> parse(std::string str);
+void verifyLex(std::string &line, uint32_t &openParen, uint32_t &closedParen);
 
-std::istream &getInput(std::istream &in, std::string &str,
-                       std::size_t &linesRead, std::string prompt,
-                       std::string wrap);
+std::shared_ptr<SExpr> parse(std::string str);
 
 #endif


### PR DESCRIPTION
Integrate GNU Readline library and other UX improvements
- Allows users to move text cursor (through ← and → keys)
- Allows users to "scroll" command history (through ↑ and ↓ keys)
- Supports a [subset of Emacs keyboard shortcuts](https://tiswww.case.edu/php/chet/readline/readline.html#index-command-editing)
- Prints translation date and time on interactive mode startup