### PR TITLE
`error`

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ _Happy hacking!_
 | Function            | Description                                                   |
 | ------------------- | ------------------------------------------------------------- |
 | (**quit**)          | Quits the session.                                            |
+| (**error** _msg_)   | Throws a runtime error with _msg_ as the message.             |
 | (**dis** _closure_) | Prints the disassembled bytecode for _closure_, returns `'()` |
 | (**display** _arg_) | Prints arg to std::cout, returns `'()`.                       |
 

--- a/src/runtime/Env.cpp
+++ b/src/runtime/Env.cpp
@@ -41,7 +41,9 @@ Env::Env() {
 
   BIND_NATIVE_FN("dis", lispDis, 1);
   BIND_NATIVE_FN("display", lispDisplay, 1);
+
   BIND_NATIVE_FN("quit", lispQuit, 0);
+  BIND_NATIVE_FN("error", lispError, 1);
 
   BIND_NATIVE_FN("eq?", lispEq, 2);
   BIND_NATIVE_FN("eqv?", lispEqv, 2);

--- a/src/runtime/NatFnImpls.cpp
+++ b/src/runtime/NatFnImpls.cpp
@@ -173,11 +173,19 @@ lispDisplay(std::vector<std::shared_ptr<SExpr>>::iterator params,
   }
   return std::make_shared<NilAtom>();
 }
+
 std::shared_ptr<SExpr>
 lispQuit(std::vector<std::shared_ptr<SExpr>>::iterator params,
          const uint8_t argc) {
   std::cout << "Farewell." << std::endl;
   exit(0);
+}
+std::shared_ptr<SExpr>
+lispError(std::vector<std::shared_ptr<SExpr>>::iterator params,
+          const uint8_t argc) {
+  std::stringstream ss;
+  ss << **params;
+  throw std::runtime_error(ss.str());
 }
 
 std::shared_ptr<SExpr>

--- a/src/runtime/NatFnImpls.hpp
+++ b/src/runtime/NatFnImpls.hpp
@@ -38,7 +38,9 @@ NativeFn lispCdr;
 NativeFn lispDis;
 NativeFn lispIsClosure;
 NativeFn lispDisplay;
+
 NativeFn lispQuit;
+NativeFn lispError;
 
 NativeFn lispEq;
 NativeFn lispEqv;


### PR DESCRIPTION
### Implement `error`

Calling `error` will throw a `std::runtime_error`

```scheme
Lisp (C++ std: 202002, Jun  4 2023, 19:58:14)
Type "(quit)" or trigger EOF to exit the session.
lisp> (define bomb
  ...   (lambda (explode?)
  ...     (if explode? (error "boom!") "tik")))
<Closure at 0x600003138338>
lisp> (bomb #f)
"tik"
lisp> (bomb #t)
In <std::cin>
In code object with ip: 11
Constants:
    error, "boom!", "tik"
Bytecodes (raw):
    0a 01 0d 00 09 05 00 04 01 01 01 0c 00 02 04 02
    02
Bytecodes:
    3                  0 LOAD_STACK              1
    3                  2 POP_JUMP_IF_FALSE       9
    3                  5 LOAD_SYM                error
    3                  7 LOAD_CONST              "boom!"
    3                  9 CALL                    1
    3                 11 JUMP                    2
    3                 14 LOAD_CONST              "tik"
    ?                 16 RETURN
Call stack:
    0       <Closure: 0x6000031200b8, ip: 6, bp: 0>
    1       <Closure: 0x600003138338, ip: 11, bp: 1> (bomb)
Data stack:
    0       <Closure at 0x6000031200b8>
    1       <Closure at 0x600003138338> (bomb)
    2       #t
    3       <Native function> (error)
    4       "boom!"
Runtime error: "boom!"
lisp>
```