### PR TITLE
Tracing garbage collection

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS_EXTRA = -fsanitize=address -g
+CXXFLAGS_EXTRA = -fsanitize=address,undefined -g
 CXXFLAGS = -std=c++20 -Wall $(CXXFLAGS_EXTRA)
 
 PERCENT = %

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS_EXTRA =
+CXXFLAGS_EXTRA = -fsanitize=address -g
 CXXFLAGS = -std=c++20 -Wall $(CXXFLAGS_EXTRA)
 
 PERCENT = %

--- a/makefile
+++ b/makefile
@@ -28,8 +28,8 @@ _DEPS =  common/sexpr/Atom.hpp \
 	common/sexpr/NilAtom.hpp common/sexpr/SExpr.hpp common/sexpr/SExprs.hpp \
 	common/sexpr/StringAtom.hpp common/sexpr/SymAtom.hpp common/Code.hpp \
 	common/TypeError.hpp compile/Compiler.hpp compile/SyntaxError.hpp \
-	repl/repl.hpp runtime/Env.hpp runtime/NatFnImpls.hpp runtime/Upvalue.hpp \
-	runtime/VM.hpp
+	repl/repl.hpp runtime/Env.hpp runtime/NatFnImpls.hpp \
+	runtime/RuntimeError.hpp runtime/Upvalue.hpp runtime/VM.hpp
 
 DEPS = $(addprefix $(SRCDIR)/,$(_DEPS))
 OBJS = $(patsubst %.hpp,$(OUTDIR)/%.o,$(subst /,_,$(_DEPS)))

--- a/makefile
+++ b/makefile
@@ -1,6 +1,8 @@
 CXX = g++
-CXXFLAGS_EXTRA = -fsanitize=address,undefined -g
-CXXFLAGS = -std=c++20 -Wall $(CXXFLAGS_EXTRA)
+CXXFLAGS = -std=c++20 $(CXXFLAGS_ASAN) $(CXXFLAGS_WARN) $(CXXFLAGS_EXTRA)
+CXXFLAGS_ASAN = -fsanitize=address,undefined -g
+CXXFLAGS_WARN = -pedantic -Wall -Wextra -Wno-gnu-label-as-value -Wno-unused-parameter
+CXXFLAGS_EXTRA =
 
 PERCENT = %
 define NEWLINE

--- a/src/common/Code.cpp
+++ b/src/common/Code.cpp
@@ -87,7 +87,7 @@ std::ostream &operator<<(std::ostream &o, const Code &code) {
     case OpCode::MAKE_CLOSURE: {
       const auto fn = cast<FnAtom>(code.consts[READ_BYTE()]);
       o << "MAKE_CLOSURE" << *fn;
-      for (unsigned int i{0}; i < fn->numUpVals; i++) {
+      for (unsigned int i{0}; i < fn->numUpvals; i++) {
         const auto isLocal = unsigned(READ_BYTE());
         const auto idx = unsigned(READ_BYTE());
         o << std::endl

--- a/src/common/Code.cpp
+++ b/src/common/Code.cpp
@@ -13,7 +13,7 @@ uint8_t Code::pushCode(const uint8_t code, const unsigned int lineNum) {
   return byteCodes.size() - 1;
 }
 
-uint8_t Code::pushConst(std::shared_ptr<SExpr> sExpr) {
+uint8_t Code::pushConst(SExpr *sExpr) {
   consts.push_back(sExpr);
   return consts.size() - 1;
 }

--- a/src/common/Code.cpp
+++ b/src/common/Code.cpp
@@ -13,7 +13,7 @@ uint8_t Code::pushCode(const uint8_t code, const unsigned int lineNum) {
   return byteCodes.size() - 1;
 }
 
-uint8_t Code::pushConst(SExpr *sExpr) {
+uint8_t Code::pushConst(const SExpr *sExpr) {
   consts.push_back(sExpr);
   return consts.size() - 1;
 }

--- a/src/common/Code.hpp
+++ b/src/common/Code.hpp
@@ -12,13 +12,13 @@ class Code {
 
 public:
   std::vector<uint8_t> byteCodes;
-  std::vector<SExpr *> consts;
+  std::vector<const SExpr *> consts;
 
   std::vector<unsigned int> lineNums;
 
   uint8_t pushCode(const uint8_t code);
   uint8_t pushCode(const uint8_t code, const unsigned int lineNum);
-  uint8_t pushConst(SExpr *sExpr);
+  uint8_t pushConst(const SExpr *sExpr);
 
   void patchJump(const std::vector<uint8_t>::size_type idx);
 };

--- a/src/common/Code.hpp
+++ b/src/common/Code.hpp
@@ -12,13 +12,13 @@ class Code {
 
 public:
   std::vector<uint8_t> byteCodes;
-  std::vector<std::shared_ptr<SExpr>> consts;
+  std::vector<SExpr *> consts;
 
   std::vector<unsigned int> lineNums;
 
   uint8_t pushCode(const uint8_t code);
   uint8_t pushCode(const uint8_t code, const unsigned int lineNum);
-  uint8_t pushConst(std::shared_ptr<SExpr> sExpr);
+  uint8_t pushConst(SExpr *sExpr);
 
   void patchJump(const std::vector<uint8_t>::size_type idx);
 };

--- a/src/common/TypeError.cpp
+++ b/src/common/TypeError.cpp
@@ -3,7 +3,7 @@
 #include <memory>
 
 TypeError::TypeError(const std::string &msg, const std::string expected,
-                     const std::shared_ptr<SExpr> actual)
+                     SExpr *const actual)
     : _msg(msg), expected(expected), actual(actual) {}
 
 const char *TypeError::what() const noexcept { return _msg.c_str(); }

--- a/src/common/TypeError.cpp
+++ b/src/common/TypeError.cpp
@@ -3,7 +3,7 @@
 #include <memory>
 
 TypeError::TypeError(const std::string &msg, const std::string expected,
-                     SExpr *const actual)
+                     const SExpr *const actual)
     : _msg(msg), expected(expected), actual(actual) {}
 
 const char *TypeError::what() const noexcept { return _msg.c_str(); }

--- a/src/common/TypeError.hpp
+++ b/src/common/TypeError.hpp
@@ -13,12 +13,12 @@ private:
 
 public:
   TypeError(const std::string &msg, const std::string expected,
-            const std::shared_ptr<SExpr> actual);
+            SExpr *const actual);
 
   virtual const char *what() const noexcept override;
 
   const std::string expected;
-  const std::shared_ptr<SExpr> actual;
+  SExpr *const actual;
 };
 
 std::ostream &operator<<(std::ostream &o, const TypeError &pe);

--- a/src/common/TypeError.hpp
+++ b/src/common/TypeError.hpp
@@ -13,12 +13,12 @@ private:
 
 public:
   TypeError(const std::string &msg, const std::string expected,
-            SExpr *const actual);
+            const SExpr *const actual);
 
   virtual const char *what() const noexcept override;
 
   const std::string expected;
-  SExpr *const actual;
+  const SExpr *const actual;
 };
 
 std::ostream &operator<<(std::ostream &o, const TypeError &pe);

--- a/src/common/cast.cpp
+++ b/src/common/cast.cpp
@@ -13,9 +13,10 @@ template <typename To, typename From> To *cast(From *f) {
   if (auto ptr = dynamic_cast<To *>(f)) {
     return ptr;
   }
-  std::cout << "Mismatched types. Expected " << To::typeName << ", but got "
-            << *f << ".";
-  return nullptr;
+  std::stringstream ss;
+  ss << "Mismatched types. Expected " << To::typeName << ", but got " << *f
+     << ".";
+  throw TypeError(ss.str(), To::typeName, f);
 }
 
 #endif

--- a/src/common/cast.cpp
+++ b/src/common/cast.cpp
@@ -13,12 +13,29 @@ template <typename To, typename From> bool isa(From *f) {
   return To::classOf(*f);
 }
 
-template <typename To, typename From> const To *cast(const From *f) {
-  if (auto ptr = dynamic_cast<const To *>(f)) {
-    return ptr;
+template <typename To, typename From> const To *dynCast(const From *f) {
+  if (isa<To>(f)) {
+    return static_cast<const To *>(f);
+  }
+  return nullptr;
+}
+
+template <typename To, typename From> const To &cast(const From &f) {
+  if (isa<To>(f)) {
+    return static_cast<const To &>(f);
   }
   std::stringstream ss;
-  ss << "Mismatched types. Expected " << To::typeName << ", but got " << *f
+  ss << "Mismatched types. Expected " << To::typeName << ", but got " << f
+     << ".";
+  throw TypeError(ss.str(), To::typeName, &f);
+}
+
+template <typename To, typename From> const To *cast(const From *f) {
+  if (isa<To>(f)) {
+    return static_cast<const To *>(f);
+  }
+  std::stringstream ss;
+  ss << "Mismatched types. Expected " << To::typeName << ", but got " << f
      << ".";
   throw TypeError(ss.str(), To::typeName, f);
 }

--- a/src/common/cast.cpp
+++ b/src/common/cast.cpp
@@ -9,6 +9,10 @@ template <typename To, typename From> bool isa(From &f) {
   return To::classOf(f);
 }
 
+template <typename To, typename From> bool isa(From *f) {
+  return To::classOf(*f);
+}
+
 template <typename To, typename From> const To *cast(const From *f) {
   if (auto ptr = dynamic_cast<const To *>(f)) {
     return ptr;

--- a/src/common/cast.cpp
+++ b/src/common/cast.cpp
@@ -9,8 +9,8 @@ template <typename To, typename From> bool isa(From &f) {
   return To::classOf(f);
 }
 
-template <typename To, typename From> To *cast(From *f) {
-  if (auto ptr = dynamic_cast<To *>(f)) {
+template <typename To, typename From> const To *cast(const From *f) {
+  if (auto ptr = dynamic_cast<const To *>(f)) {
     return ptr;
   }
   std::stringstream ss;

--- a/src/common/cast.cpp
+++ b/src/common/cast.cpp
@@ -9,15 +9,13 @@ template <typename To, typename From> bool isa(From &f) {
   return To::classOf(f);
 }
 
-template <typename To, typename From>
-std::shared_ptr<To> cast(std::shared_ptr<From> f) {
-  if (auto ptr = std::dynamic_pointer_cast<To>(f)) {
+template <typename To, typename From> To *cast(From *f) {
+  if (auto ptr = dynamic_cast<To *>(f)) {
     return ptr;
   }
-  std::stringstream ss;
-  ss << "Mismatched types. Expected " << To::typeName << ", but got " << *f
-     << ".";
-  throw TypeError(ss.str(), To::typeName, f);
+  std::cout << "Mismatched types. Expected " << To::typeName << ", but got "
+            << *f << ".";
+  return nullptr;
 }
 
 #endif

--- a/src/common/sexpr/BoolAtom.cpp
+++ b/src/common/sexpr/BoolAtom.cpp
@@ -9,7 +9,7 @@ std::string BoolAtom::toString() const { return (val) ? "#t" : "#f"; }
 
 bool BoolAtom::equals(const SExpr &other) const {
   if (isa<BoolAtom>(other)) {
-    return val == dynamic_cast<const BoolAtom &>(other).val;
+    return val == cast<BoolAtom>(other).val;
   }
   return false;
 }

--- a/src/common/sexpr/BoolAtom.cpp
+++ b/src/common/sexpr/BoolAtom.cpp
@@ -3,17 +3,7 @@
 #include <memory>
 #include <string>
 
-bool BoolAtom::toBool(SExpr *sExpr) {
-  if (auto boolAtom = dynamic_cast<BoolAtom *>(sExpr)) {
-    return boolAtom->val;
-  }
-  return true;
-}
-
 BoolAtom::BoolAtom(const bool val) : Atom(SExpr::Type::BOOL), val(val) {}
-
-BoolAtom::BoolAtom(SExpr *const sExpr)
-    : Atom(SExpr::Type::BOOL), val(toBool(sExpr)) {}
 
 std::string BoolAtom::toString() const { return (val) ? "#t" : "#f"; }
 
@@ -24,8 +14,25 @@ bool BoolAtom::equals(const SExpr &other) const {
   return false;
 }
 
+BoolAtom *BoolAtom::getInstance(const bool val) {
+  if (val) {
+    return &BoolAtom::_true;
+  }
+  return &BoolAtom::_false;
+}
+
+bool BoolAtom::toBool(SExpr *sExpr) {
+  if (auto boolAtom = dynamic_cast<BoolAtom *>(sExpr)) {
+    return boolAtom->val;
+  }
+  return true;
+}
+
 bool BoolAtom::classOf(const SExpr &sExpr) {
   return sExpr.type == SExpr::Type::BOOL;
 }
+
+BoolAtom BoolAtom::_true(true);
+BoolAtom BoolAtom::_false(false);
 
 const std::string BoolAtom::typeName = "<Boolean>";

--- a/src/common/sexpr/BoolAtom.cpp
+++ b/src/common/sexpr/BoolAtom.cpp
@@ -22,8 +22,8 @@ BoolAtom *BoolAtom::getInstance(const bool val) {
 }
 
 bool BoolAtom::toBool(const SExpr *sExpr) {
-  if (auto boolAtom = dynamic_cast<const BoolAtom *>(sExpr)) {
-    return boolAtom->val;
+  if (sExpr == &_false) {
+    return false;
   }
   return true;
 }

--- a/src/common/sexpr/BoolAtom.cpp
+++ b/src/common/sexpr/BoolAtom.cpp
@@ -3,8 +3,8 @@
 #include <memory>
 #include <string>
 
-bool BoolAtom::toBool(std::shared_ptr<SExpr> sExpr) {
-  if (auto boolAtom = std::dynamic_pointer_cast<BoolAtom>(sExpr)) {
+bool BoolAtom::toBool(SExpr *sExpr) {
+  if (auto boolAtom = dynamic_cast<BoolAtom *>(sExpr)) {
     return boolAtom->val;
   }
   return true;
@@ -12,7 +12,7 @@ bool BoolAtom::toBool(std::shared_ptr<SExpr> sExpr) {
 
 BoolAtom::BoolAtom(const bool val) : Atom(SExpr::Type::BOOL), val(val) {}
 
-BoolAtom::BoolAtom(const std::shared_ptr<SExpr> sExpr)
+BoolAtom::BoolAtom(SExpr *const sExpr)
     : Atom(SExpr::Type::BOOL), val(toBool(sExpr)) {}
 
 std::string BoolAtom::toString() const { return (val) ? "#t" : "#f"; }

--- a/src/common/sexpr/BoolAtom.cpp
+++ b/src/common/sexpr/BoolAtom.cpp
@@ -21,8 +21,8 @@ BoolAtom *BoolAtom::getInstance(const bool val) {
   return &BoolAtom::_false;
 }
 
-bool BoolAtom::toBool(SExpr *sExpr) {
-  if (auto boolAtom = dynamic_cast<BoolAtom *>(sExpr)) {
+bool BoolAtom::toBool(const SExpr *sExpr) {
+  if (auto boolAtom = dynamic_cast<const BoolAtom *>(sExpr)) {
     return boolAtom->val;
   }
   return true;

--- a/src/common/sexpr/BoolAtom.hpp
+++ b/src/common/sexpr/BoolAtom.hpp
@@ -15,9 +15,9 @@ public:
   const bool val;
 
   BoolAtom(const bool val);
-  BoolAtom(const std::shared_ptr<SExpr> sExpr);
+  BoolAtom(SExpr *const sExpr);
 
-  static bool toBool(const std::shared_ptr<SExpr> sExpr);
+  static bool toBool(SExpr *const sExpr);
   static bool classOf(const SExpr &sExpr);
   static const std::string typeName;
 };

--- a/src/common/sexpr/BoolAtom.hpp
+++ b/src/common/sexpr/BoolAtom.hpp
@@ -21,7 +21,7 @@ public:
 
   const bool val;
 
-  static bool toBool(SExpr *const sExpr);
+  static bool toBool(const SExpr *const sExpr);
   static bool classOf(const SExpr &sExpr);
   static const std::string typeName;
 

--- a/src/common/sexpr/BoolAtom.hpp
+++ b/src/common/sexpr/BoolAtom.hpp
@@ -8,18 +8,25 @@
 
 class BoolAtom final : public Atom {
 protected:
+  BoolAtom(const bool val);
+
+  static BoolAtom _true;
+  static BoolAtom _false;
+
   std::string toString() const;
   bool equals(const SExpr &other) const;
 
 public:
-  const bool val;
+  static BoolAtom *getInstance(const bool val);
 
-  BoolAtom(const bool val);
-  BoolAtom(SExpr *const sExpr);
+  const bool val;
 
   static bool toBool(SExpr *const sExpr);
   static bool classOf(const SExpr &sExpr);
   static const std::string typeName;
+
+  BoolAtom(BoolAtom &other) = delete;
+  void operator=(const BoolAtom &) = delete;
 };
 
 #endif

--- a/src/common/sexpr/ClosureAtom.cpp
+++ b/src/common/sexpr/ClosureAtom.cpp
@@ -5,7 +5,7 @@
 #include <iomanip>
 #include <sstream>
 
-ClosureAtom::ClosureAtom(const std::shared_ptr<FnAtom> fnAtom)
+ClosureAtom::ClosureAtom(FnAtom *const fnAtom)
     : Atom(SExpr::Type::CLOSURE), fnAtom(fnAtom) {}
 
 void ClosureAtom::assertArity(const uint8_t argc) const {

--- a/src/common/sexpr/ClosureAtom.cpp
+++ b/src/common/sexpr/ClosureAtom.cpp
@@ -5,8 +5,12 @@
 #include <iomanip>
 #include <sstream>
 
-ClosureAtom::ClosureAtom(FnAtom *const fnAtom)
+ClosureAtom::ClosureAtom(const FnAtom *fnAtom)
     : Atom(SExpr::Type::CLOSURE), fnAtom(fnAtom) {}
+
+ClosureAtom::ClosureAtom(const FnAtom *fnAtom,
+                         const std::vector<std::shared_ptr<Upvalue>> upvalues)
+    : Atom(SExpr::Type::CLOSURE), fnAtom(fnAtom), upvalues(upvalues) {}
 
 void ClosureAtom::assertArity(const uint8_t argc) const {
   if (fnAtom->arity != -1 && argc != (uint8_t)fnAtom->arity) {
@@ -17,7 +21,7 @@ void ClosureAtom::assertArity(const uint8_t argc) const {
   }
 }
 
-std::ostream &ClosureAtom::dissassemble(std::ostream &o) {
+std::ostream &ClosureAtom::dissassemble(std::ostream &o) const {
   const unsigned int PADDING_WIDTH = 4;
   o << "<Closure at " << this << ">, instance of:" << std::endl
     << std::setw(PADDING_WIDTH) << "";

--- a/src/common/sexpr/ClosureAtom.cpp
+++ b/src/common/sexpr/ClosureAtom.cpp
@@ -43,7 +43,7 @@ std::string ClosureAtom::toString() const {
 
 bool ClosureAtom::equals(const SExpr &other) const {
   if (isa<ClosureAtom>(other)) {
-    const auto closure = dynamic_cast<const ClosureAtom &>(other);
+    const auto closure = cast<ClosureAtom>(other);
     if (fnAtom != closure.fnAtom) {
       return false;
     }

--- a/src/common/sexpr/ClosureAtom.hpp
+++ b/src/common/sexpr/ClosureAtom.hpp
@@ -14,14 +14,16 @@ protected:
   bool equals(const SExpr &other) const;
 
 public:
-  ClosureAtom(FnAtom *const fnAtom);
+  ClosureAtom(const FnAtom *fnAtom);
+  ClosureAtom(const FnAtom *fnAtom,
+              const std::vector<std::shared_ptr<Upvalue>> upvalues);
 
   void assertArity(const uint8_t arity) const;
 
-  FnAtom *const fnAtom;
-  std::vector<std::shared_ptr<Upvalue>> upvalues;
+  const FnAtom *const fnAtom;
+  const std::vector<std::shared_ptr<Upvalue>> upvalues;
 
-  std::ostream &dissassemble(std::ostream &o);
+  std::ostream &dissassemble(std::ostream &o) const;
 
   static bool classOf(const SExpr &sExpr);
   static const std::string typeName;

--- a/src/common/sexpr/ClosureAtom.hpp
+++ b/src/common/sexpr/ClosureAtom.hpp
@@ -14,11 +14,11 @@ protected:
   bool equals(const SExpr &other) const;
 
 public:
-  ClosureAtom(const std::shared_ptr<FnAtom> fnAtom);
+  ClosureAtom(FnAtom *const fnAtom);
 
   void assertArity(const uint8_t arity) const;
 
-  const std::shared_ptr<FnAtom> fnAtom;
+  FnAtom *const fnAtom;
   std::vector<std::shared_ptr<Upvalue>> upvalues;
 
   std::ostream &dissassemble(std::ostream &o);

--- a/src/common/sexpr/FnAtom.cpp
+++ b/src/common/sexpr/FnAtom.cpp
@@ -2,8 +2,10 @@
 #include <memory>
 #include <sstream>
 
-FnAtom::FnAtom(int8_t arity)
-    : Atom(SExpr::Type::FUNCTION), arity(arity), numUpVals(0) {}
+FnAtom::FnAtom(const int8_t arity, const unsigned int numUpvals,
+               const Code code)
+    : Atom(SExpr::Type::FUNCTION), arity(arity), numUpvals(numUpvals),
+      code(code) {}
 
 std::string FnAtom::toString() const {
   std::stringstream ss;
@@ -15,7 +17,7 @@ bool FnAtom::equals(const SExpr &other) const { return this == &other; }
 
 std::ostream &FnAtom::dissassemble(std::ostream &o) const {
   o << "<Function at " << this << ", arity: " << unsigned(arity)
-    << ", upvalues: " << numUpVals << ">" << std::endl
+    << ", upvalues: " << numUpvals << ">" << std::endl
     << code << std::endl;
   for (auto i = code.consts.begin(); i != code.consts.end(); ++i) {
     if (const auto fnAtom = dynamic_cast<FnAtom *>(*i)) {

--- a/src/common/sexpr/FnAtom.cpp
+++ b/src/common/sexpr/FnAtom.cpp
@@ -13,12 +13,12 @@ std::string FnAtom::toString() const {
 
 bool FnAtom::equals(const SExpr &other) const { return this == &other; }
 
-std::ostream &FnAtom::dissassemble(std::ostream &o) {
+std::ostream &FnAtom::dissassemble(std::ostream &o) const {
   o << "<Function at " << this << ", arity: " << unsigned(arity)
     << ", upvalues: " << numUpVals << ">" << std::endl
     << code << std::endl;
   for (auto i = code.consts.begin(); i != code.consts.end(); ++i) {
-    if (const auto fnAtom = std::dynamic_pointer_cast<FnAtom>(*i)) {
+    if (const auto fnAtom = dynamic_cast<FnAtom *>(*i)) {
       fnAtom->dissassemble(o);
     }
   }

--- a/src/common/sexpr/FnAtom.cpp
+++ b/src/common/sexpr/FnAtom.cpp
@@ -1,4 +1,5 @@
 #include "FnAtom.hpp"
+#include "../cast.cpp"
 #include <memory>
 #include <sstream>
 
@@ -20,7 +21,7 @@ std::ostream &FnAtom::dissassemble(std::ostream &o) const {
     << ", upvalues: " << numUpvals << ">" << std::endl
     << code << std::endl;
   for (auto i = code.consts.begin(); i != code.consts.end(); ++i) {
-    if (const auto fnAtom = dynamic_cast<const FnAtom *>(*i)) {
+    if (const auto fnAtom = dynCast<FnAtom>(*i)) {
       fnAtom->dissassemble(o);
     }
   }

--- a/src/common/sexpr/FnAtom.cpp
+++ b/src/common/sexpr/FnAtom.cpp
@@ -20,7 +20,7 @@ std::ostream &FnAtom::dissassemble(std::ostream &o) const {
     << ", upvalues: " << numUpvals << ">" << std::endl
     << code << std::endl;
   for (auto i = code.consts.begin(); i != code.consts.end(); ++i) {
-    if (const auto fnAtom = dynamic_cast<FnAtom *>(*i)) {
+    if (const auto fnAtom = dynamic_cast<const FnAtom *>(*i)) {
       fnAtom->dissassemble(o);
     }
   }

--- a/src/common/sexpr/FnAtom.hpp
+++ b/src/common/sexpr/FnAtom.hpp
@@ -16,7 +16,7 @@ public:
   const int8_t arity;
   unsigned int numUpVals;
 
-  std::ostream &dissassemble(std::ostream &o);
+  std::ostream &dissassemble(std::ostream &o) const;
 
   static bool classOf(const SExpr &sExpr);
   static const std::string typeName;

--- a/src/common/sexpr/FnAtom.hpp
+++ b/src/common/sexpr/FnAtom.hpp
@@ -10,11 +10,11 @@ protected:
   bool equals(const SExpr &other) const;
 
 public:
-  FnAtom(int8_t arity);
+  FnAtom(const int8_t arity, const unsigned int numUpvals, const Code code);
 
-  Code code;
   const int8_t arity;
-  unsigned int numUpVals;
+  const unsigned int numUpvals;
+  const Code code;
 
   std::ostream &dissassemble(std::ostream &o) const;
 

--- a/src/common/sexpr/IntAtom.cpp
+++ b/src/common/sexpr/IntAtom.cpp
@@ -8,7 +8,7 @@ std::string IntAtom::toString() const { return std::to_string(val); }
 
 bool IntAtom::equals(const SExpr &other) const {
   if (isa<IntAtom>(other)) {
-    return val == dynamic_cast<const IntAtom &>(other).val;
+    return val == cast<IntAtom>(other).val;
   }
   return false;
 }

--- a/src/common/sexpr/NatFnAtom.cpp
+++ b/src/common/sexpr/NatFnAtom.cpp
@@ -8,16 +8,15 @@
 NatFnAtom::NatFnAtom(NativeFn fn, const int argc)
     : Atom(SExpr::Type::NATIVE_FN), fn(fn), argc(argc) {}
 
-std::shared_ptr<SExpr>
-NatFnAtom::invoke(std::vector<std::shared_ptr<SExpr>>::iterator params,
-                  const unsigned int incomingArgc) {
+SExpr *NatFnAtom::invoke(std::vector<SExpr *>::iterator params,
+                         const unsigned int incomingArgc, VM &vm) {
   if (argc != -1 && incomingArgc != (unsigned int)argc) {
     std::stringstream ss;
     ss << "Invalid number of arguments. Expected " << argc
        << " arguments, but got " << incomingArgc << ".";
     throw std::invalid_argument(ss.str());
   }
-  return fn(params, incomingArgc);
+  return fn(params, incomingArgc, vm);
 }
 
 std::string NatFnAtom::toString() const { return "<Native function>"; }

--- a/src/common/sexpr/NatFnAtom.cpp
+++ b/src/common/sexpr/NatFnAtom.cpp
@@ -8,8 +8,8 @@
 NatFnAtom::NatFnAtom(NativeFn fn, const int argc)
     : Atom(SExpr::Type::NATIVE_FN), fn(fn), argc(argc) {}
 
-SExpr *NatFnAtom::invoke(std::vector<SExpr *>::iterator params,
-                         const unsigned int incomingArgc, VM &vm) {
+const SExpr *NatFnAtom::invoke(std::vector<const SExpr *>::iterator params,
+                               const unsigned int incomingArgc, VM &vm) const {
   if (argc != -1 && incomingArgc != (unsigned int)argc) {
     std::stringstream ss;
     ss << "Invalid number of arguments. Expected " << argc

--- a/src/common/sexpr/NatFnAtom.hpp
+++ b/src/common/sexpr/NatFnAtom.hpp
@@ -18,8 +18,8 @@ public:
 
   NatFnAtom(NativeFn fn, const int argc);
 
-  std::shared_ptr<SExpr> invoke(std::vector<std::shared_ptr<SExpr>>::iterator,
-                                const unsigned int argc);
+  SExpr *invoke(std::vector<SExpr *>::iterator, const unsigned int argc,
+                VM &vm);
   static bool classOf(const SExpr &sExpr);
   static const std::string typeName;
 };

--- a/src/common/sexpr/NatFnAtom.hpp
+++ b/src/common/sexpr/NatFnAtom.hpp
@@ -18,8 +18,8 @@ public:
 
   NatFnAtom(NativeFn fn, const int argc);
 
-  SExpr *invoke(std::vector<SExpr *>::iterator, const unsigned int argc,
-                VM &vm);
+  const SExpr *invoke(std::vector<const SExpr *>::iterator,
+                      const unsigned int argc, VM &vm) const;
   static bool classOf(const SExpr &sExpr);
   static const std::string typeName;
 };

--- a/src/common/sexpr/NilAtom.cpp
+++ b/src/common/sexpr/NilAtom.cpp
@@ -10,13 +10,12 @@ std::string NilAtom::toString() const { return "()"; }
 
 bool NilAtom::equals(const SExpr &other) const { return isa<NilAtom>(other); }
 
-NilAtom *NilAtom::getInstance() {
-  static NilAtom instance;
-  return &instance;
-}
+NilAtom *NilAtom::getInstance() { return &instance; }
 
 bool NilAtom::classOf(const SExpr &sExpr) {
   return sExpr.type == SExpr::Type::NIL;
 }
+
+NilAtom NilAtom::instance;
 
 const std::string NilAtom::typeName = "()";

--- a/src/common/sexpr/NilAtom.cpp
+++ b/src/common/sexpr/NilAtom.cpp
@@ -1,5 +1,6 @@
 #include "NilAtom.hpp"
 #include "../cast.cpp"
+#include <cstddef>
 #include <memory>
 #include <string>
 
@@ -8,6 +9,11 @@ NilAtom::NilAtom() : Atom(SExpr::Type::NIL) {}
 std::string NilAtom::toString() const { return "()"; }
 
 bool NilAtom::equals(const SExpr &other) const { return isa<NilAtom>(other); }
+
+NilAtom *NilAtom::getInstance() {
+  static NilAtom instance;
+  return &instance;
+}
 
 bool NilAtom::classOf(const SExpr &sExpr) {
   return sExpr.type == SExpr::Type::NIL;

--- a/src/common/sexpr/NilAtom.hpp
+++ b/src/common/sexpr/NilAtom.hpp
@@ -6,14 +6,19 @@
 
 class NilAtom final : public Atom {
 protected:
+  NilAtom();
+
   std::string toString() const;
   bool equals(const SExpr &other) const;
 
 public:
-  NilAtom();
+  static NilAtom *getInstance();
 
   static bool classOf(const SExpr &sExpr);
   static const std::string typeName;
+
+  NilAtom(NilAtom &other) = delete;
+  void operator=(const NilAtom &) = delete;
 };
 
 #endif

--- a/src/common/sexpr/NilAtom.hpp
+++ b/src/common/sexpr/NilAtom.hpp
@@ -8,6 +8,8 @@ class NilAtom final : public Atom {
 protected:
   NilAtom();
 
+  static NilAtom instance;
+
   std::string toString() const;
   bool equals(const SExpr &other) const;
 

--- a/src/common/sexpr/SExpr.cpp
+++ b/src/common/sexpr/SExpr.cpp
@@ -5,6 +5,8 @@
 
 SExpr::SExpr(SExpr::Type type) : type(type) {}
 
+SExpr::~SExpr() {}
+
 std::ostream &operator<<(std::ostream &o, const SExpr &sExpr) {
   return o << (isa<SExprs>(sExpr) ? "(" : "") << sExpr.toString();
 }

--- a/src/common/sexpr/SExpr.hpp
+++ b/src/common/sexpr/SExpr.hpp
@@ -19,6 +19,7 @@ public:
   const Type type;
 
   SExpr(SExpr::Type type);
+  virtual ~SExpr();
 };
 
 std::ostream &operator<<(std::ostream &o, const SExpr &sExpr);

--- a/src/common/sexpr/SExprs.cpp
+++ b/src/common/sexpr/SExprs.cpp
@@ -6,7 +6,7 @@
 #include <sstream>
 #include <string>
 
-SExprs::SExprs(std::shared_ptr<SExpr> first, std::shared_ptr<SExpr> rest)
+SExprs::SExprs(SExpr *first, SExpr *rest)
     : SExpr(SExpr::Type::SEXPRS), first(first), rest(rest) {}
 
 SExprs::SExprs() : SExpr(SExpr::Type::SEXPRS), first(nullptr), rest(nullptr) {}

--- a/src/common/sexpr/SExprs.cpp
+++ b/src/common/sexpr/SExprs.cpp
@@ -27,7 +27,7 @@ std::string SExprs::toString() const {
 
 bool SExprs::equals(const SExpr &other) const {
   if (isa<SExprs>(other)) {
-    const auto sExprs = dynamic_cast<const SExprs &>(other);
+    const auto sExprs = cast<SExprs>(other);
     return first->equals(*sExprs.first) && rest->equals(*sExprs.rest);
   }
   return false;

--- a/src/common/sexpr/SExprs.cpp
+++ b/src/common/sexpr/SExprs.cpp
@@ -13,14 +13,14 @@ SExprs::SExprs() : SExpr(SExpr::Type::SEXPRS), first(nullptr), rest(nullptr) {}
 
 std::string SExprs::toString() const {
   std::string str = "";
-  str += isa<SExprs>(*first) ? "(" : "";
+  str += isa<SExprs>(first) ? "(" : "";
   str += first->toString();
-  if (isa<NilAtom>(*rest)) {
+  if (isa<NilAtom>(rest)) {
     str += ")";
-  } else if (!isa<SExprs>(*rest)) {
+  } else if (!isa<SExprs>(rest)) {
     str += " . " + rest->toString() + ")";
   } else {
-    str += isa<NilAtom>(*rest) ? ")" : " " + rest->toString();
+    str += isa<NilAtom>(rest) ? ")" : " " + rest->toString();
   }
   return str;
 }

--- a/src/common/sexpr/SExprs.cpp
+++ b/src/common/sexpr/SExprs.cpp
@@ -6,7 +6,7 @@
 #include <sstream>
 #include <string>
 
-SExprs::SExprs(SExpr *first, SExpr *rest)
+SExprs::SExprs(const SExpr *first, const SExpr *rest)
     : SExpr(SExpr::Type::SEXPRS), first(first), rest(rest) {}
 
 SExprs::SExprs() : SExpr(SExpr::Type::SEXPRS), first(nullptr), rest(nullptr) {}

--- a/src/common/sexpr/SExprs.hpp
+++ b/src/common/sexpr/SExprs.hpp
@@ -11,10 +11,10 @@ protected:
   bool equals(const SExpr &other) const;
 
 public:
-  std::shared_ptr<SExpr> first;
-  std::shared_ptr<SExpr> rest;
+  SExpr *first;
+  SExpr *rest;
 
-  SExprs(std::shared_ptr<SExpr> first, std::shared_ptr<SExpr> rest);
+  SExprs(SExpr *first, SExpr *rest);
   SExprs();
 
   static bool classOf(const SExpr &sExpr);

--- a/src/common/sexpr/SExprs.hpp
+++ b/src/common/sexpr/SExprs.hpp
@@ -11,10 +11,10 @@ protected:
   bool equals(const SExpr &other) const;
 
 public:
-  SExpr *first;
-  SExpr *rest;
+  const SExpr *first;
+  const SExpr *rest;
 
-  SExprs(SExpr *first, SExpr *rest);
+  SExprs(const SExpr *first, const SExpr *rest);
   SExprs();
 
   static bool classOf(const SExpr &sExpr);

--- a/src/common/sexpr/StringAtom.cpp
+++ b/src/common/sexpr/StringAtom.cpp
@@ -17,7 +17,7 @@ std::string StringAtom::unescape(const std::string literal) {
 
 bool StringAtom::equals(const SExpr &other) const {
   if (isa<StringAtom>(other)) {
-    return literal == dynamic_cast<const StringAtom &>(other).literal;
+    return literal == cast<StringAtom>(other).literal;
   }
   return false;
 }

--- a/src/common/sexpr/SymAtom.cpp
+++ b/src/common/sexpr/SymAtom.cpp
@@ -9,7 +9,7 @@ std::string SymAtom::toString() const { return val; }
 
 bool SymAtom::equals(const SExpr &other) const {
   if (isa<SymAtom>(other)) {
-    return val == dynamic_cast<const SymAtom &>(other).val;
+    return val == cast<SymAtom>(other).val;
   }
   return false;
 }

--- a/src/common/sexpr/SymAtom.cpp
+++ b/src/common/sexpr/SymAtom.cpp
@@ -20,6 +20,11 @@ bool SymAtom::classOf(const SExpr &sExpr) {
 
 const std::string SymAtom::typeName = "<Symbol>";
 
-size_t SymAtom::HashFunction::operator()(const SymAtom &sym) const {
-  return std::hash<std::string>()(sym.val);
+size_t SymAtom::HashFunction::operator()(const SymAtom *sym) const {
+  return std::hash<std::string>()(sym->val);
+}
+
+bool SymAtom::EqualFunction::operator()(const SymAtom *lhs,
+                                        const SymAtom *rhs) const {
+  return *lhs == *rhs;
 }

--- a/src/common/sexpr/SymAtom.hpp
+++ b/src/common/sexpr/SymAtom.hpp
@@ -20,7 +20,12 @@ public:
 
   class HashFunction {
   public:
-    size_t operator()(const SymAtom &sym) const;
+    size_t operator()(const SymAtom *sym) const;
+  };
+
+  class EqualFunction {
+  public:
+    bool operator()(const SymAtom *lhs, const SymAtom *rhs) const;
   };
 };
 

--- a/src/compile/Compiler.cpp
+++ b/src/compile/Compiler.cpp
@@ -188,7 +188,7 @@ void Compiler::compile(SExpr *sExpr) {
     } else if (sym->val == "lambda") {
       compileLambda(sExpr);
       return;
-    } else if (vm.isMacro(*sym)) {
+    } else if (vm.isMacro(sym)) {
       compile(expandMacro(sExpr));
       return;
     }
@@ -273,7 +273,7 @@ void Compiler::compileDefMacro(SExpr *sExpr) {
     getCode().pushCode(OpCode::DEF_SYM, lineNum);
     getCode().pushCode(getCode().pushConst(sym), lineNum);
 
-    vm.defMacro(*sym);
+    vm.defMacro(sym);
   } catch (TypeError &te) {
     handleSyntaxError(defMacroGrammar, te.expected, te.actual);
   }

--- a/src/compile/Compiler.cpp
+++ b/src/compile/Compiler.cpp
@@ -28,13 +28,13 @@ Compiler::Compiler(const std::vector<std::string> source, SourceLoc sourceLoc,
                    VM &vm)
     : source(source), sourceLoc(sourceLoc), vm(vm), enclosing(enclosing),
       arg(arg), body(body), stackOffset(1) {
-  if (const auto argNames = dynamic_cast<const SExprs *>(arg)) {
+  if (const auto argNames = dynCast<SExprs>(arg)) {
     visitEach(argNames, [&](const SExpr *sExpr) {
       auto sym = cast<SymAtom>(sExpr);
       locals.push_back({sym, stackOffset, false});
       stackOffset += 1;
     });
-  } else if (const auto argName = dynamic_cast<const SymAtom *>(arg)) {
+  } else if (const auto argName = dynCast<SymAtom>(arg)) {
     locals.push_back({argName, stackOffset, false});
     stackOffset += 1;
   } else if (!isa<NilAtom>(arg)) {
@@ -161,12 +161,12 @@ void Compiler::compile(const SExpr *sExpr) {
     code.pushCode(OpCode::LOAD_CONST, lineNum);
     code.pushCode(code.pushConst(sExpr), lineNum);
     return;
-  } else if (const auto sym = dynamic_cast<const SymAtom *>(sExpr)) {
+  } else if (const auto sym = dynCast<SymAtom>(sExpr)) {
     compileSym(sym);
     return;
   }
   const auto sExprs = cast<SExprs>(sExpr);
-  if (const auto sym = dynamic_cast<const SymAtom *>(sExprs->first)) {
+  if (const auto sym = dynCast<SymAtom>(sExprs->first)) {
     if (sym->val == "quote") {
       compileQuote(sExpr);
       return;

--- a/src/compile/Compiler.cpp
+++ b/src/compile/Compiler.cpp
@@ -37,7 +37,7 @@ Compiler::Compiler(const std::vector<std::string> source, SourceLoc sourceLoc,
   } else if (const auto argName = dynamic_cast<const SymAtom *>(arg)) {
     locals.push_back({argName, stackOffset, false});
     stackOffset += 1;
-  } else if (!isa<NilAtom>(*arg)) {
+  } else if (!isa<NilAtom>(arg)) {
     handleSyntaxError(lambdaGrammar, NilAtom::typeName, arg);
   }
 }
@@ -155,8 +155,8 @@ const SExpr *Compiler::parseSexprs(std::vector<Token>::const_iterator &it,
 }
 
 void Compiler::compile(const SExpr *sExpr) {
-  if (isa<NilAtom>(*sExpr) || isa<IntAtom>(*sExpr) || isa<BoolAtom>(*sExpr) ||
-      isa<StringAtom>(*sExpr)) {
+  if (isa<NilAtom>(sExpr) || isa<IntAtom>(sExpr) || isa<BoolAtom>(sExpr) ||
+      isa<StringAtom>(sExpr)) {
     const auto lineNum = std::get<0>(sourceLoc[sExpr]);
     code.pushCode(OpCode::LOAD_CONST, lineNum);
     code.pushCode(code.pushConst(sExpr), lineNum);
@@ -391,7 +391,7 @@ const SExpr *Compiler::expandMacro(const SExpr *sExpr) {
 unsigned int Compiler::visitEach(const SExpr *sExprs, Visitor visitor) {
   auto numVisited = 0U;
   auto cur = sExprs;
-  while (isa<SExprs>(*cur)) {
+  while (isa<SExprs>(cur)) {
     auto sExprs = cast<SExprs>(cur);
     visitor(sExprs->first);
     cur = sExprs->rest;
@@ -465,7 +465,7 @@ Compiler::Compiler(std::vector<std::string> source, VM &vm)
       body(parse(source, sourceLoc)), stackOffset(0) {}
 
 const FnAtom *Compiler::compile() {
-  if (isa<SymAtom>(*arg)) {
+  if (isa<SymAtom>(arg)) {
     code.pushCode(OpCode::MAKE_LIST);
   }
 
@@ -483,7 +483,7 @@ const FnAtom *Compiler::compile() {
   }
   code.pushCode(OpCode::RETURN);
 
-  if (isa<SymAtom>(*arg)) {
+  if (isa<SymAtom>(arg)) {
     return vm.alloc<FnAtom>(-1, upValues.size(), code);
   }
 

--- a/src/compile/Compiler.cpp
+++ b/src/compile/Compiler.cpp
@@ -242,7 +242,7 @@ void Compiler::compileDef(SExpr *sExpr) {
       getCode().pushCode(OpCode::DEF_SYM, lineNum);
       getCode().pushCode(getCode().pushConst(sym), lineNum);
     } else {
-      locals.push_back({sym, stackOffset});
+      locals.push_back({sym, stackOffset, false});
     }
   } catch (TypeError &te) {
     handleSyntaxError(defGrammar, te.expected, te.actual);
@@ -391,7 +391,7 @@ SExpr *Compiler::expandMacro(SExpr *sExpr) {
   return vm.exec(macroExpr);
 }
 
-const unsigned int Compiler::visitEach(SExpr *sExprs, Visitor visitor) {
+unsigned int Compiler::visitEach(SExpr *sExprs, Visitor visitor) {
   auto numVisited = 0U;
   auto cur = sExprs;
   while (isa<SExprs>(*cur)) {

--- a/src/compile/Compiler.cpp
+++ b/src/compile/Compiler.cpp
@@ -385,7 +385,7 @@ const SExpr *Compiler::expandMacro(const SExpr *sExpr) {
   macro.pushCode(argc);
   macro.pushCode(OpCode::RETURN);
 
-  return vm.exec(vm.alloc<FnAtom>(0, 0, macro));
+  return vm.eval(vm.alloc<FnAtom>(0, 0, macro));
 }
 
 unsigned int Compiler::visitEach(const SExpr *sExprs, Visitor visitor) {

--- a/src/compile/Compiler.hpp
+++ b/src/compile/Compiler.hpp
@@ -43,9 +43,12 @@ private:
   VM &vm;
 
   Compiler *const enclosing;
+
+  Code code;
+
   SExpr *const arg;
   SExpr *const body;
-  FnAtom *function;
+
   std::vector<Local> locals;
   std::vector<UpValue> upValues;
   uint8_t stackOffset;
@@ -76,7 +79,6 @@ private:
 
   unsigned int visitEach(SExpr *sExpr, Visitor visitor);
   SExpr *at(const unsigned int n, SExpr *sExpr);
-  Code &getCode();
 
   int resolveLocal(SymAtom *sym);
   int resolveUpvalue(Compiler &caller, SymAtom *sym);

--- a/src/compile/Compiler.hpp
+++ b/src/compile/Compiler.hpp
@@ -74,7 +74,7 @@ private:
 
   SExpr *expandMacro(SExpr *macro);
 
-  const unsigned int visitEach(SExpr *sExpr, Visitor visitor);
+  unsigned int visitEach(SExpr *sExpr, Visitor visitor);
   SExpr *at(const unsigned int n, SExpr *sExpr);
   Code &getCode();
 

--- a/src/compile/Compiler.hpp
+++ b/src/compile/Compiler.hpp
@@ -14,7 +14,7 @@
 
 class Compiler {
 private:
-  typedef std::unordered_map<std::shared_ptr<SExpr>,
+  typedef std::unordered_map<SExpr *,
                              std::tuple<const unsigned int, const unsigned int>>
       SourceLoc;
 
@@ -24,10 +24,10 @@ private:
     std::string str;
   };
 
-  typedef std::function<void(std::shared_ptr<SExpr>)> Visitor;
+  typedef std::function<void(SExpr *)> Visitor;
 
   struct Local {
-    const std::shared_ptr<SymAtom> symbol;
+    SymAtom *const symbol;
     const uint8_t stackOffset;
     bool isCaptured;
   };
@@ -43,57 +43,54 @@ private:
   VM &vm;
 
   Compiler *const enclosing;
-  const std::shared_ptr<SExpr> arg;
-  const std::shared_ptr<SExpr> body;
-  std::shared_ptr<FnAtom> function;
+  SExpr *const arg;
+  SExpr *const body;
+  FnAtom *function;
   std::vector<Local> locals;
   std::vector<UpValue> upValues;
   uint8_t stackOffset;
 
   Compiler(const std::vector<std::string> source, SourceLoc sourceLoc,
-           std::shared_ptr<SExpr> arg, std::shared_ptr<SExpr> body,
-           Compiler *enclosing, VM &vm);
+           SExpr *arg, SExpr *body, Compiler *enclosing, VM &vm);
 
   static std::vector<Token> tokenize(std::vector<std::string> lines);
   static std::vector<Token> tokenize(std::string line, const unsigned int row);
 
-  static std::shared_ptr<SExpr> parse(std::vector<std::string> lines,
-                                      SourceLoc &sourceLoc);
-  static std::shared_ptr<SExpr> parse(std::vector<Token>::const_iterator &it,
-                                      SourceLoc &sourceLoc);
-  static std::shared_ptr<SExpr> parseAtom(Token token);
-  static std::shared_ptr<SExpr>
-  parseSexprs(std::vector<Token>::const_iterator &it, SourceLoc &sourceLoc);
+  SExpr *parse(std::vector<std::string> lines, SourceLoc &sourceLoc);
+  SExpr *parse(std::vector<Token>::const_iterator &it, SourceLoc &sourceLoc);
+  SExpr *parseAtom(Token token);
+  SExpr *parseSexprs(std::vector<Token>::const_iterator &it,
+                     SourceLoc &sourceLoc);
 
-  void compile(std::shared_ptr<SExpr> sExpr);
-  void compileSym(std::shared_ptr<SymAtom> sym);
-  void compileQuote(std::shared_ptr<SExpr> sExpr);
-  void compileDef(std::shared_ptr<SExpr> sExpr);
-  void compileDefMacro(std::shared_ptr<SExpr> sExpr);
-  void compileSet(std::shared_ptr<SExpr> sExpr);
-  void compileIf(std::shared_ptr<SExpr> sExpr);
-  void compileLambda(std::shared_ptr<SExpr> sExpr);
-  void compileCall(std::shared_ptr<SExprs> sExprs);
+  void compile(SExpr *sExpr);
+  void compileSym(SymAtom *sym);
+  void compileQuote(SExpr *sExpr);
+  void compileDef(SExpr *sExpr);
+  void compileDefMacro(SExpr *sExpr);
+  void compileSet(SExpr *sExpr);
+  void compileIf(SExpr *sExpr);
+  void compileLambda(SExpr *sExpr);
+  void compileCall(SExprs *sExprs);
 
-  std::shared_ptr<SExpr> expandMacro(std::shared_ptr<SExpr>);
+  SExpr *expandMacro(SExpr *macro);
 
-  const unsigned int visitEach(std::shared_ptr<SExpr> sExpr, Visitor visitor);
-  std::shared_ptr<SExpr> at(const unsigned int n, std::shared_ptr<SExpr> sExpr);
+  const unsigned int visitEach(SExpr *sExpr, Visitor visitor);
+  SExpr *at(const unsigned int n, SExpr *sExpr);
   Code &getCode();
 
-  int resolveLocal(std::shared_ptr<SymAtom> sym);
-  int resolveUpvalue(Compiler &caller, std::shared_ptr<SymAtom> sym);
+  int resolveLocal(SymAtom *sym);
+  int resolveUpvalue(Compiler &caller, SymAtom *sym);
   int addUpvalue(int idx, bool isLocal);
 
   static void handleUnexpectedToken(const Token &token,
                                     const std::string &line);
   void handleSyntaxError(const std::string grammar, const std::string expected,
-                         const std::shared_ptr<SExpr> actual);
+                         SExpr *const actual);
 
 public:
   Compiler(std::vector<std::string> source, VM &vm);
 
-  std::shared_ptr<FnAtom> compile();
+  FnAtom *compile();
 
   static void verifyLex(std::string &line, const unsigned int lineNum,
                         uint32_t &openParen, uint32_t &closedParen);

--- a/src/compile/Compiler.hpp
+++ b/src/compile/Compiler.hpp
@@ -14,7 +14,7 @@
 
 class Compiler {
 private:
-  typedef std::unordered_map<SExpr *,
+  typedef std::unordered_map<const SExpr *,
                              std::tuple<const unsigned int, const unsigned int>>
       SourceLoc;
 
@@ -24,10 +24,10 @@ private:
     std::string str;
   };
 
-  typedef std::function<void(SExpr *)> Visitor;
+  typedef std::function<void(const SExpr *)> Visitor;
 
   struct Local {
-    SymAtom *const symbol;
+    const SymAtom *const symbol;
     const uint8_t stackOffset;
     bool isCaptured;
   };
@@ -46,53 +46,54 @@ private:
 
   Code code;
 
-  SExpr *const arg;
-  SExpr *const body;
+  const SExpr *const arg;
+  const SExpr *const body;
 
   std::vector<Local> locals;
   std::vector<UpValue> upValues;
   uint8_t stackOffset;
 
   Compiler(const std::vector<std::string> source, SourceLoc sourceLoc,
-           SExpr *arg, SExpr *body, Compiler *enclosing, VM &vm);
+           const SExpr *arg, const SExpr *body, Compiler *enclosing, VM &vm);
 
   static std::vector<Token> tokenize(std::vector<std::string> lines);
   static std::vector<Token> tokenize(std::string line, const unsigned int row);
 
-  SExpr *parse(std::vector<std::string> lines, SourceLoc &sourceLoc);
-  SExpr *parse(std::vector<Token>::const_iterator &it, SourceLoc &sourceLoc);
-  SExpr *parseAtom(Token token);
-  SExpr *parseSexprs(std::vector<Token>::const_iterator &it,
+  const SExpr *parse(std::vector<std::string> lines, SourceLoc &sourceLoc);
+  const SExpr *parse(std::vector<Token>::const_iterator &it,
                      SourceLoc &sourceLoc);
+  const SExpr *parseAtom(Token token);
+  const SExpr *parseSexprs(std::vector<Token>::const_iterator &it,
+                           SourceLoc &sourceLoc);
 
-  void compile(SExpr *sExpr);
-  void compileSym(SymAtom *sym);
-  void compileQuote(SExpr *sExpr);
-  void compileDef(SExpr *sExpr);
-  void compileDefMacro(SExpr *sExpr);
-  void compileSet(SExpr *sExpr);
-  void compileIf(SExpr *sExpr);
-  void compileLambda(SExpr *sExpr);
-  void compileCall(SExprs *sExprs);
+  void compile(const SExpr *sExpr);
+  void compileSym(const SymAtom *sym);
+  void compileQuote(const SExpr *sExpr);
+  void compileDef(const SExpr *sExpr);
+  void compileDefMacro(const SExpr *sExpr);
+  void compileSet(const SExpr *sExpr);
+  void compileIf(const SExpr *sExpr);
+  void compileLambda(const SExpr *sExpr);
+  void compileCall(const SExprs *sExprs);
 
-  SExpr *expandMacro(SExpr *macro);
+  const SExpr *expandMacro(const SExpr *macro);
 
-  unsigned int visitEach(SExpr *sExpr, Visitor visitor);
-  SExpr *at(const unsigned int n, SExpr *sExpr);
+  unsigned int visitEach(const SExpr *sExpr, Visitor visitor);
+  const SExpr *at(const unsigned int n, const SExpr *sExpr);
 
-  int resolveLocal(SymAtom *sym);
-  int resolveUpvalue(Compiler &caller, SymAtom *sym);
+  int resolveLocal(const SymAtom *sym);
+  int resolveUpvalue(Compiler &caller, const SymAtom *sym);
   int addUpvalue(int idx, bool isLocal);
 
   static void handleUnexpectedToken(const Token &token,
                                     const std::string &line);
   void handleSyntaxError(const std::string grammar, const std::string expected,
-                         SExpr *const actual);
+                         const SExpr *const actual);
 
 public:
   Compiler(std::vector<std::string> source, VM &vm);
 
-  FnAtom *compile();
+  const FnAtom *compile();
 
   static void verifyLex(std::string &line, const unsigned int lineNum,
                         uint32_t &openParen, uint32_t &closedParen);

--- a/src/repl/repl.cpp
+++ b/src/repl/repl.cpp
@@ -73,7 +73,7 @@ int execFile(const std::string filePath, VM &vm) {
       if (getFileInput(fs, lines)) {
         Compiler compiler(lines, vm);
         auto main = compiler.compile();
-        vm.exec(main);
+        vm.evalWithGC(main);
       } else {
         break;
       }
@@ -129,7 +129,7 @@ int repl() {
       if (getConsoleInput(lines, "lisp> ", "  ... ")) {
         Compiler compiler(lines, vm);
         auto main = compiler.compile();
-        const auto res = vm.exec(main);
+        const auto res = vm.evalWithGC(main);
         std::cout << *res << std::endl;
       } else {
         std::cout << std::endl << "Farewell." << std::endl;

--- a/src/repl/repl.cpp
+++ b/src/repl/repl.cpp
@@ -1,6 +1,7 @@
 #include "repl.hpp"
 #include "../compile/Compiler.hpp"
 #include "../compile/SyntaxError.hpp"
+#include "../runtime/RuntimeError.hpp"
 #include "../runtime/VM.hpp"
 #include <cstdlib>
 #include <cstring>
@@ -80,7 +81,7 @@ int execFile(const std::string filePath, VM &vm) {
       std::cerr << "In line " << lines.size() << " of \"" << filePath << "\""
                 << std::endl
                 << se;
-    } catch (VM::RuntimeException &re) {
+    } catch (RuntimeError &re) {
       std::cerr << "In line " << lines.size() << " of \"" << filePath << "\""
                 << std::endl
                 << re;
@@ -136,7 +137,7 @@ int repl() {
       }
     } catch (SyntaxError &se) {
       std::cerr << "In <std::cin>" << std::endl << se << std::endl;
-    } catch (VM::RuntimeException &re) {
+    } catch (RuntimeError &re) {
       std::cerr << "In <std::cin>" << std::endl << re << std::endl;
     }
   }

--- a/src/runtime/Env.cpp
+++ b/src/runtime/Env.cpp
@@ -1,60 +1,10 @@
 #include "Env.hpp"
-#include "../common/sexpr/NatFnAtom.hpp"
 #include "../common/sexpr/SExpr.hpp"
-#include "NatFnImpls.hpp"
 #include <iostream>
 #include <memory>
 #include <stdexcept>
 
-Env::Env() {
-#define BIND_NATIVE_FN(sym, func, argc)                                        \
-  do {                                                                         \
-    symTable.insert({SymAtom(sym), std::make_shared<NatFnAtom>(&func, argc)}); \
-  } while (false)
-
-  BIND_NATIVE_FN("sym?", lispIsSym, 1);
-  BIND_NATIVE_FN("gensym", lispGenSym, 0);
-
-  BIND_NATIVE_FN("num?", lispIsNum, 1);
-  BIND_NATIVE_FN("=", lispNumEq, -1);
-  BIND_NATIVE_FN(">", lispGt, -1);
-  BIND_NATIVE_FN(">=", lispGteq, -1);
-  BIND_NATIVE_FN("<", lispLt, -1);
-  BIND_NATIVE_FN("<=", lispLteq, -1);
-  BIND_NATIVE_FN("+", lispAdd, -1);
-  BIND_NATIVE_FN("*", lispMult, -1);
-  BIND_NATIVE_FN("-", lispSub, -1);
-  BIND_NATIVE_FN("/", lispDiv, -1);
-  BIND_NATIVE_FN("abs", lispAbs, 1);
-  BIND_NATIVE_FN("%", lispMod, 2);
-
-  BIND_NATIVE_FN("str?", lispIsStr, 1);
-  BIND_NATIVE_FN("str-len", lispStrLen, 1);
-  BIND_NATIVE_FN("str-sub", lispStrSub, 3);
-  BIND_NATIVE_FN("str-con", lispStrCon, -1);
-  BIND_NATIVE_FN("->str", lispToStr, 1);
-
-  BIND_NATIVE_FN("null?", lispIsNull, 1);
-  BIND_NATIVE_FN("cons?", lispIsCons, 1);
-  BIND_NATIVE_FN("cons", lispCons, 2);
-  BIND_NATIVE_FN("car", lispCar, 1);
-  BIND_NATIVE_FN("cdr", lispCdr, 1);
-
-  BIND_NATIVE_FN("dis", lispDis, 1);
-  BIND_NATIVE_FN("display", lispDisplay, 1);
-
-  BIND_NATIVE_FN("quit", lispQuit, 0);
-  BIND_NATIVE_FN("error", lispError, 1);
-
-  BIND_NATIVE_FN("eq?", lispEq, 2);
-  BIND_NATIVE_FN("eqv?", lispEqv, 2);
-
-  BIND_NATIVE_FN("proc?", lispIsProc, 1);
-
-#undef BIND_NATIVE_FN
-}
-
-void Env::def(SymAtom &sym, std::shared_ptr<SExpr> val) {
+void Env::def(SymAtom &sym, SExpr *val) {
   auto it = symTable.find(sym);
   if (it != symTable.end()) {
     throw std::invalid_argument("Symbol \"" + sym.val +
@@ -63,7 +13,7 @@ void Env::def(SymAtom &sym, std::shared_ptr<SExpr> val) {
   symTable.insert({sym, val});
 }
 
-void Env::set(SymAtom &sym, std::shared_ptr<SExpr> val) {
+void Env::set(SymAtom &sym, SExpr *val) {
   auto it = symTable.find(sym);
   if (it == symTable.end()) {
     throw std::invalid_argument("Symbol \"" + sym.val + "\" is not defined.");
@@ -71,7 +21,7 @@ void Env::set(SymAtom &sym, std::shared_ptr<SExpr> val) {
   symTable[sym] = val;
 }
 
-std::shared_ptr<SExpr> Env::find(SymAtom &sym) {
+SExpr *Env::find(SymAtom &sym) {
   auto it = symTable.find(sym);
   if (it == symTable.end()) {
     throw std::invalid_argument("Symbol \"" + sym.val + "\" is not defined.");

--- a/src/runtime/Env.cpp
+++ b/src/runtime/Env.cpp
@@ -4,7 +4,7 @@
 #include <memory>
 #include <stdexcept>
 
-void Env::def(SymAtom *sym, SExpr *val) {
+void Env::def(const SymAtom *sym, const SExpr *val) {
   auto it = symTable.find(sym);
   if (it != symTable.end()) {
     throw std::invalid_argument("Symbol \"" + sym->val +
@@ -13,7 +13,7 @@ void Env::def(SymAtom *sym, SExpr *val) {
   symTable.insert({sym, val});
 }
 
-void Env::set(SymAtom *sym, SExpr *val) {
+void Env::set(const SymAtom *sym, const SExpr *val) {
   auto it = symTable.find(sym);
   if (it == symTable.end()) {
     throw std::invalid_argument("Symbol \"" + sym->val + "\" is not defined.");
@@ -21,7 +21,7 @@ void Env::set(SymAtom *sym, SExpr *val) {
   symTable[sym] = val;
 }
 
-SExpr *Env::find(SymAtom *sym) {
+const SExpr *Env::find(const SymAtom *sym) {
   auto it = symTable.find(sym);
   if (it == symTable.end()) {
     throw std::invalid_argument("Symbol \"" + sym->val + "\" is not defined.");
@@ -31,6 +31,8 @@ SExpr *Env::find(SymAtom *sym) {
 
 const Env::SymVals &Env::getSymTable() const { return symTable; }
 
-void Env::defMacro(SymAtom *sym) { macros.insert(sym); }
+void Env::defMacro(const SymAtom *sym) { macros.insert(sym); }
 
-bool Env::isMacro(SymAtom *sym) { return macros.find(sym) != macros.end(); }
+bool Env::isMacro(const SymAtom *sym) {
+  return macros.find(sym) != macros.end();
+}

--- a/src/runtime/Env.cpp
+++ b/src/runtime/Env.cpp
@@ -4,33 +4,33 @@
 #include <memory>
 #include <stdexcept>
 
-void Env::def(SymAtom &sym, SExpr *val) {
+void Env::def(SymAtom *sym, SExpr *val) {
   auto it = symTable.find(sym);
   if (it != symTable.end()) {
-    throw std::invalid_argument("Symbol \"" + sym.val +
+    throw std::invalid_argument("Symbol \"" + sym->val +
                                 "\" is already defined.");
   }
   symTable.insert({sym, val});
 }
 
-void Env::set(SymAtom &sym, SExpr *val) {
+void Env::set(SymAtom *sym, SExpr *val) {
   auto it = symTable.find(sym);
   if (it == symTable.end()) {
-    throw std::invalid_argument("Symbol \"" + sym.val + "\" is not defined.");
+    throw std::invalid_argument("Symbol \"" + sym->val + "\" is not defined.");
   }
   symTable[sym] = val;
 }
 
-SExpr *Env::find(SymAtom &sym) {
+SExpr *Env::find(SymAtom *sym) {
   auto it = symTable.find(sym);
   if (it == symTable.end()) {
-    throw std::invalid_argument("Symbol \"" + sym.val + "\" is not defined.");
+    throw std::invalid_argument("Symbol \"" + sym->val + "\" is not defined.");
   }
   return it->second;
 }
 
 const Env::SymVals &Env::getSymTable() const { return symTable; }
 
-void Env::defMacro(SymAtom &sym) { macros.insert(sym); }
+void Env::defMacro(SymAtom *sym) { macros.insert(sym); }
 
-bool Env::isMacro(SymAtom &sym) { return macros.find(sym) != macros.end(); }
+bool Env::isMacro(SymAtom *sym) { return macros.find(sym) != macros.end(); }

--- a/src/runtime/Env.hpp
+++ b/src/runtime/Env.hpp
@@ -8,28 +8,30 @@
 #include <unordered_set>
 
 class Env {
-  typedef std::unordered_map<SymAtom, SExpr *, SymAtom::HashFunction> SymVals;
+  typedef std::unordered_map<SymAtom *, SExpr *, SymAtom::HashFunction,
+                             SymAtom::EqualFunction>
+      SymVals;
 
-  typedef std::unordered_set<SymAtom, SymAtom::HashFunction> Macros;
+  typedef std::unordered_set<SymAtom *, SymAtom::HashFunction,
+                             SymAtom::EqualFunction>
+      Macros;
 
 private:
   SymVals symTable;
   Macros macros;
 
 public:
-  Env();
+  void def(SymAtom *sym, SExpr *val);
 
-  void def(SymAtom &sym, SExpr *val);
-
-  void set(SymAtom &sym, SExpr *val);
+  void set(SymAtom *sym, SExpr *val);
 
   const SymVals &getSymTable() const;
 
-  SExpr *find(SymAtom &sym);
+  SExpr *find(SymAtom *sym);
 
-  void defMacro(SymAtom &sym);
+  void defMacro(SymAtom *sym);
 
-  bool isMacro(SymAtom &sym);
+  bool isMacro(SymAtom *sym);
 };
 
 #endif

--- a/src/runtime/Env.hpp
+++ b/src/runtime/Env.hpp
@@ -11,7 +11,6 @@ class Env {
   typedef std::unordered_map<const SymAtom *, const SExpr *,
                              SymAtom::HashFunction, SymAtom::EqualFunction>
       SymVals;
-  friend class VM;
 
   typedef std::unordered_set<const SymAtom *, SymAtom::HashFunction,
                              SymAtom::EqualFunction>

--- a/src/runtime/Env.hpp
+++ b/src/runtime/Env.hpp
@@ -8,11 +8,11 @@
 #include <unordered_set>
 
 class Env {
-  typedef std::unordered_map<SymAtom *, SExpr *, SymAtom::HashFunction,
-                             SymAtom::EqualFunction>
+  typedef std::unordered_map<const SymAtom *, const SExpr *,
+                             SymAtom::HashFunction, SymAtom::EqualFunction>
       SymVals;
 
-  typedef std::unordered_set<SymAtom *, SymAtom::HashFunction,
+  typedef std::unordered_set<const SymAtom *, SymAtom::HashFunction,
                              SymAtom::EqualFunction>
       Macros;
 
@@ -21,17 +21,17 @@ private:
   Macros macros;
 
 public:
-  void def(SymAtom *sym, SExpr *val);
+  void def(const SymAtom *sym, const SExpr *val);
 
-  void set(SymAtom *sym, SExpr *val);
+  void set(const SymAtom *sym, const SExpr *val);
 
   const SymVals &getSymTable() const;
 
-  SExpr *find(SymAtom *sym);
+  const SExpr *find(const SymAtom *sym);
 
-  void defMacro(SymAtom *sym);
+  void defMacro(const SymAtom *sym);
 
-  bool isMacro(SymAtom *sym);
+  bool isMacro(const SymAtom *sym);
 };
 
 #endif

--- a/src/runtime/Env.hpp
+++ b/src/runtime/Env.hpp
@@ -11,6 +11,7 @@ class Env {
   typedef std::unordered_map<const SymAtom *, const SExpr *,
                              SymAtom::HashFunction, SymAtom::EqualFunction>
       SymVals;
+  friend class VM;
 
   typedef std::unordered_set<const SymAtom *, SymAtom::HashFunction,
                              SymAtom::EqualFunction>

--- a/src/runtime/Env.hpp
+++ b/src/runtime/Env.hpp
@@ -8,9 +8,7 @@
 #include <unordered_set>
 
 class Env {
-  typedef std::unordered_map<SymAtom, std::shared_ptr<SExpr>,
-                             SymAtom::HashFunction>
-      SymVals;
+  typedef std::unordered_map<SymAtom, SExpr *, SymAtom::HashFunction> SymVals;
 
   typedef std::unordered_set<SymAtom, SymAtom::HashFunction> Macros;
 
@@ -21,13 +19,13 @@ private:
 public:
   Env();
 
-  void def(SymAtom &sym, std::shared_ptr<SExpr> val);
+  void def(SymAtom &sym, SExpr *val);
 
-  void set(SymAtom &sym, std::shared_ptr<SExpr> val);
+  void set(SymAtom &sym, SExpr *val);
 
   const SymVals &getSymTable() const;
 
-  std::shared_ptr<SExpr> find(SymAtom &sym);
+  SExpr *find(SymAtom &sym);
 
   void defMacro(SymAtom &sym);
 

--- a/src/runtime/NatFnImpls.cpp
+++ b/src/runtime/NatFnImpls.cpp
@@ -59,7 +59,7 @@
     return vm.alloc<BoolAtom>(cond);                                           \
   }
 
-PRED_OP(lispIsSym, isa<SymAtom>(**params));
+PRED_OP(lispIsSym, isa<SymAtom>(*params));
 
 long genSymCnt = 0;
 const SExpr *lispGenSym(std::vector<const SExpr *>::iterator params,
@@ -70,7 +70,7 @@ const SExpr *lispGenSym(std::vector<const SExpr *>::iterator params,
   return vm.alloc<SymAtom>(ss.str());
 }
 
-PRED_OP(lispIsNum, isa<IntAtom>(**params));
+PRED_OP(lispIsNum, isa<IntAtom>(*params));
 MATH_CMP_OP(lispNumEq, ==);
 MATH_CMP_OP(lispGt, >);
 MATH_CMP_OP(lispGteq, >=);
@@ -92,7 +92,7 @@ const SExpr *lispMod(std::vector<const SExpr *>::iterator params,
   return vm.alloc<IntAtom>(lhs % rhs);
 }
 
-PRED_OP(lispIsStr, isa<StringAtom>(**params));
+PRED_OP(lispIsStr, isa<StringAtom>(*params));
 const SExpr *lispStrLen(std::vector<const SExpr *>::iterator params,
                         const uint8_t argc, VM &vm) {
   return vm.alloc<IntAtom>(cast<StringAtom>(*params)->unescaped.size());
@@ -126,7 +126,7 @@ const SExpr *lispStrCon(std::vector<const SExpr *>::iterator params,
 }
 const SExpr *lispToStr(std::vector<const SExpr *>::iterator params,
                        const uint8_t argc, VM &vm) {
-  if (isa<StringAtom>(**params)) {
+  if (isa<StringAtom>(*params)) {
     return *params;
   }
   std::stringstream ss;
@@ -139,8 +139,8 @@ const SExpr *lispToStr(std::vector<const SExpr *>::iterator params,
   return vm.alloc<StringAtom>(ss.str());
 }
 
-PRED_OP(lispIsNull, isa<NilAtom>(**params));
-PRED_OP(lispIsCons, isa<SExprs>(**params));
+PRED_OP(lispIsNull, isa<NilAtom>(*params));
+PRED_OP(lispIsCons, isa<SExprs>(*params));
 const SExpr *lispCons(std::vector<const SExpr *>::iterator params,
                       const uint8_t argc, VM &vm) {
   return vm.alloc<SExprs>(*params, *(params + 1));
@@ -192,8 +192,8 @@ const SExpr *lispEqv(std::vector<const SExpr *>::iterator params,
 
 const SExpr *lispIsProc(std::vector<const SExpr *>::iterator params,
                         const uint8_t argc, VM &vm) {
-  return vm.alloc<BoolAtom>(isa<ClosureAtom>(**params) ||
-                            isa<NatFnAtom>(**params));
+  return vm.alloc<BoolAtom>(isa<ClosureAtom>(*params) ||
+                            isa<NatFnAtom>(*params));
 }
 
 #undef MATH_CMP_OP

--- a/src/runtime/NatFnImpls.cpp
+++ b/src/runtime/NatFnImpls.cpp
@@ -161,7 +161,7 @@ const SExpr *lispDis(std::vector<const SExpr *>::iterator params,
 }
 const SExpr *lispDisplay(std::vector<const SExpr *>::iterator params,
                          const uint8_t argc, VM &vm) {
-  if (auto stringAtom = dynamic_cast<const StringAtom *>(*params)) {
+  if (auto stringAtom = dynCast<StringAtom>(*params)) {
     std::cout << stringAtom->unescaped << std::endl;
   } else {
     std::cout << **params << std::endl;

--- a/src/runtime/NatFnImpls.cpp
+++ b/src/runtime/NatFnImpls.cpp
@@ -14,38 +14,35 @@
 #include <stdexcept>
 
 #define MATH_CMP_OP(name, op)                                                  \
-  std::shared_ptr<SExpr> name(                                                 \
-      std::vector<std::shared_ptr<SExpr>>::iterator params,                    \
-      const uint8_t argc) {                                                    \
+  SExpr *name(std::vector<SExpr *>::iterator params, const uint8_t argc,       \
+              VM &vm) {                                                        \
     const auto prev = cast<IntAtom>(*params)->val;                             \
     ++params;                                                                  \
     for (uint8_t i{1}; i < argc; ++i) {                                        \
       if (!(prev op cast<IntAtom>(*params)->val)) {                            \
-        return std::make_shared<BoolAtom>(false);                              \
+        return vm.alloc<BoolAtom>(false);                                      \
       }                                                                        \
       ++params;                                                                \
     }                                                                          \
-    return std::make_shared<BoolAtom>(true);                                   \
+    return vm.alloc<BoolAtom>(true);                                           \
   }
 
 #define MATH_CUM_OP(name, op, init)                                            \
-  std::shared_ptr<SExpr> name(                                                 \
-      std::vector<std::shared_ptr<SExpr>>::iterator params,                    \
-      const uint8_t argc) {                                                    \
+  SExpr *name(std::vector<SExpr *>::iterator params, const uint8_t argc,       \
+              VM &vm) {                                                        \
     int res = init;                                                            \
     for (uint8_t i{0}; i < argc; ++i) {                                        \
       res op cast<IntAtom>(*params)->val;                                      \
       ++params;                                                                \
     }                                                                          \
-    return std::make_shared<IntAtom>(res);                                     \
+    return vm.alloc<IntAtom>(res);                                             \
   }
 
 #define MATH_DIM_OP(name, op, unaryOp)                                         \
-  std::shared_ptr<SExpr> name(                                                 \
-      std::vector<std::shared_ptr<SExpr>>::iterator params,                    \
-      const uint8_t argc) {                                                    \
+  SExpr *name(std::vector<SExpr *>::iterator params, const uint8_t argc,       \
+              VM &vm) {                                                        \
     if (argc == 1) {                                                           \
-      return std::make_shared<IntAtom>(unaryOp cast<IntAtom>(*params)->val);   \
+      return vm.alloc<IntAtom>(unaryOp cast<IntAtom>(*params)->val);           \
     }                                                                          \
     int res = cast<IntAtom>(*params)->val;                                     \
     ++params;                                                                  \
@@ -53,26 +50,24 @@
       res op cast<IntAtom>(*params)->val;                                      \
       ++params;                                                                \
     }                                                                          \
-    return std::make_shared<IntAtom>(res);                                     \
+    return vm.alloc<IntAtom>(res);                                             \
   }
 
 #define PRED_OP(name, cond)                                                    \
-  std::shared_ptr<SExpr> name(                                                 \
-      std::vector<std::shared_ptr<SExpr>>::iterator params,                    \
-      const uint8_t argc) {                                                    \
-    return std::make_shared<BoolAtom>(cond);                                   \
+  SExpr *name(std::vector<SExpr *>::iterator params, const uint8_t argc,       \
+              VM &vm) {                                                        \
+    return vm.alloc<BoolAtom>(cond);                                           \
   }
 
 PRED_OP(lispIsSym, isa<SymAtom>(**params));
 
 long genSymCnt = 0;
-std::shared_ptr<SExpr>
-lispGenSym(std::vector<std::shared_ptr<SExpr>>::iterator params,
-           const uint8_t argc) {
+SExpr *lispGenSym(std::vector<SExpr *>::iterator params, const uint8_t argc,
+                  VM &vm) {
   std::stringstream ss;
   ss << ";gensym-" << genSymCnt;
   genSymCnt += 1;
-  return std::make_shared<SymAtom>(ss.str());
+  return vm.alloc<SymAtom>(ss.str());
 }
 
 PRED_OP(lispIsNum, isa<IntAtom>(**params));
@@ -85,29 +80,25 @@ MATH_CUM_OP(lispAdd, +=, 0);
 MATH_CUM_OP(lispMult, *=, 1);
 MATH_DIM_OP(lispSub, -=, 0 -);
 MATH_DIM_OP(lispDiv, /=, 1 /);
-std::shared_ptr<SExpr>
-lispAbs(std::vector<std::shared_ptr<SExpr>>::iterator params,
-        const uint8_t argc) {
-  return std::make_shared<IntAtom>(abs(cast<IntAtom>(*params)->val));
+SExpr *lispAbs(std::vector<SExpr *>::iterator params, const uint8_t argc,
+               VM &vm) {
+  return vm.alloc<IntAtom>(abs(cast<IntAtom>(*params)->val));
 }
-std::shared_ptr<SExpr>
-lispMod(std::vector<std::shared_ptr<SExpr>>::iterator params,
-        const uint8_t argc) {
+SExpr *lispMod(std::vector<SExpr *>::iterator params, const uint8_t argc,
+               VM &vm) {
   const auto lhs = cast<IntAtom>(*params)->val;
   ++params;
   const auto rhs = cast<IntAtom>(*params)->val;
-  return std::make_shared<IntAtom>(lhs % rhs);
+  return vm.alloc<IntAtom>(lhs % rhs);
 }
 
 PRED_OP(lispIsStr, isa<StringAtom>(**params));
-std::shared_ptr<SExpr>
-lispStrLen(std::vector<std::shared_ptr<SExpr>>::iterator params,
-           const uint8_t argc) {
-  return std::make_shared<IntAtom>(cast<StringAtom>(*params)->unescaped.size());
+SExpr *lispStrLen(std::vector<SExpr *>::iterator params, const uint8_t argc,
+                  VM &vm) {
+  return vm.alloc<IntAtom>(cast<StringAtom>(*params)->unescaped.size());
 }
-std::shared_ptr<SExpr>
-lispStrSub(std::vector<std::shared_ptr<SExpr>>::iterator params,
-           const uint8_t argc) {
+SExpr *lispStrSub(std::vector<SExpr *>::iterator params, const uint8_t argc,
+                  VM &vm) {
   auto str = cast<StringAtom>(*params);
   auto pos = cast<IntAtom>(*(params + 1))->val;
   auto len = cast<IntAtom>(*(params + 2))->val;
@@ -120,11 +111,10 @@ lispStrSub(std::vector<std::shared_ptr<SExpr>>::iterator params,
         << ")";
     throw std::invalid_argument(ess.str());
   }
-  return std::make_shared<StringAtom>(ss.str());
+  return vm.alloc<StringAtom>(ss.str());
 }
-std::shared_ptr<SExpr>
-lispStrCon(std::vector<std::shared_ptr<SExpr>>::iterator params,
-           const uint8_t argc) {
+SExpr *lispStrCon(std::vector<SExpr *>::iterator params, const uint8_t argc,
+                  VM &vm) {
   std::stringstream ss;
   ss << "\"";
   for (uint8_t i{0}; i < argc; ++i) {
@@ -132,11 +122,10 @@ lispStrCon(std::vector<std::shared_ptr<SExpr>>::iterator params,
     ++params;
   }
   ss << "\"";
-  return std::make_shared<StringAtom>(ss.str());
+  return vm.alloc<StringAtom>(ss.str());
 }
-std::shared_ptr<SExpr>
-lispToStr(std::vector<std::shared_ptr<SExpr>>::iterator params,
-          const uint8_t argc) {
+SExpr *lispToStr(std::vector<SExpr *>::iterator params, const uint8_t argc,
+                 VM &vm) {
   if (isa<StringAtom>(**params)) {
     return *params;
   }
@@ -147,74 +136,64 @@ lispToStr(std::vector<std::shared_ptr<SExpr>>::iterator params,
     ++params;
   }
   ss << "\"";
-  return std::make_shared<StringAtom>(ss.str());
+  return vm.alloc<StringAtom>(ss.str());
 }
 
 PRED_OP(lispIsNull, isa<NilAtom>(**params));
 PRED_OP(lispIsCons, isa<SExprs>(**params));
-std::shared_ptr<SExpr>
-lispCons(std::vector<std::shared_ptr<SExpr>>::iterator params,
-         const uint8_t argc) {
-  return std::make_shared<SExprs>(*params, *(params + 1));
+SExpr *lispCons(std::vector<SExpr *>::iterator params, const uint8_t argc,
+                VM &vm) {
+  return vm.alloc<SExprs>(*params, *(params + 1));
 }
-std::shared_ptr<SExpr>
-lispCar(std::vector<std::shared_ptr<SExpr>>::iterator params,
-        const uint8_t argc) {
+SExpr *lispCar(std::vector<SExpr *>::iterator params, const uint8_t argc,
+               VM &vm) {
   return cast<SExprs>(*params)->first;
 }
-std::shared_ptr<SExpr>
-lispCdr(std::vector<std::shared_ptr<SExpr>>::iterator params,
-        const uint8_t argc) {
+SExpr *lispCdr(std::vector<SExpr *>::iterator params, const uint8_t argc,
+               VM &vm) {
   return cast<SExprs>(*params)->rest;
 }
 
-std::shared_ptr<SExpr>
-lispDis(std::vector<std::shared_ptr<SExpr>>::iterator params,
-        const uint8_t argc) {
+SExpr *lispDis(std::vector<SExpr *>::iterator params, const uint8_t argc,
+               VM &vm) {
   cast<ClosureAtom>(*params)->dissassemble(std::cout);
-  return std::make_shared<NilAtom>();
+  return vm.alloc<NilAtom>();
 }
-std::shared_ptr<SExpr>
-lispDisplay(std::vector<std::shared_ptr<SExpr>>::iterator params,
-            const uint8_t argc) {
-  if (auto stringAtom = std::dynamic_pointer_cast<StringAtom>(*params)) {
+SExpr *lispDisplay(std::vector<SExpr *>::iterator params, const uint8_t argc,
+                   VM &vm) {
+  if (auto stringAtom = dynamic_cast<StringAtom *>(*params)) {
     std::cout << stringAtom->unescaped << std::endl;
   } else {
     std::cout << **params << std::endl;
   }
-  return std::make_shared<NilAtom>();
+  return vm.alloc<NilAtom>();
 }
 
-std::shared_ptr<SExpr>
-lispQuit(std::vector<std::shared_ptr<SExpr>>::iterator params,
-         const uint8_t argc) {
+SExpr *lispQuit(std::vector<SExpr *>::iterator params, const uint8_t argc,
+                VM &vm) {
   std::cout << "Farewell." << std::endl;
   exit(0);
 }
-std::shared_ptr<SExpr>
-lispError(std::vector<std::shared_ptr<SExpr>>::iterator params,
-          const uint8_t argc) {
+SExpr *lispError(std::vector<SExpr *>::iterator params, const uint8_t argc,
+                 VM &vm) {
   std::stringstream ss;
   ss << **params;
   throw std::runtime_error(ss.str());
 }
 
-std::shared_ptr<SExpr>
-lispEq(std::vector<std::shared_ptr<SExpr>>::iterator params,
-       const uint8_t argc) {
-  return std::make_shared<BoolAtom>((*params) == (*(params + 1)));
+SExpr *lispEq(std::vector<SExpr *>::iterator params, const uint8_t argc,
+              VM &vm) {
+  return vm.alloc<BoolAtom>((*params) == (*(params + 1)));
 }
-std::shared_ptr<SExpr>
-lispEqv(std::vector<std::shared_ptr<SExpr>>::iterator params,
-        const uint8_t argc) {
-  return std::make_shared<BoolAtom>(**params == **(params + 1));
+SExpr *lispEqv(std::vector<SExpr *>::iterator params, const uint8_t argc,
+               VM &vm) {
+  return vm.alloc<BoolAtom>(**params == **(params + 1));
 }
 
-std::shared_ptr<SExpr>
-lispIsProc(std::vector<std::shared_ptr<SExpr>>::iterator params,
-           const uint8_t argc) {
-  return std::make_shared<BoolAtom>(isa<ClosureAtom>(**params) ||
-                                    isa<NatFnAtom>(**params));
+SExpr *lispIsProc(std::vector<SExpr *>::iterator params, const uint8_t argc,
+                  VM &vm) {
+  return vm.alloc<BoolAtom>(isa<ClosureAtom>(**params) ||
+                            isa<NatFnAtom>(**params));
 }
 
 #undef MATH_CMP_OP

--- a/src/runtime/NatFnImpls.cpp
+++ b/src/runtime/NatFnImpls.cpp
@@ -14,8 +14,8 @@
 #include <stdexcept>
 
 #define MATH_CMP_OP(name, op)                                                  \
-  SExpr *name(std::vector<SExpr *>::iterator params, const uint8_t argc,       \
-              VM &vm) {                                                        \
+  const SExpr *name(std::vector<const SExpr *>::iterator params,               \
+                    const uint8_t argc, VM &vm) {                              \
     const auto prev = cast<IntAtom>(*params)->val;                             \
     ++params;                                                                  \
     for (uint8_t i{1}; i < argc; ++i) {                                        \
@@ -28,8 +28,8 @@
   }
 
 #define MATH_CUM_OP(name, op, init)                                            \
-  SExpr *name(std::vector<SExpr *>::iterator params, const uint8_t argc,       \
-              VM &vm) {                                                        \
+  const SExpr *name(std::vector<const SExpr *>::iterator params,               \
+                    const uint8_t argc, VM &vm) {                              \
     int res = init;                                                            \
     for (uint8_t i{0}; i < argc; ++i) {                                        \
       res op cast<IntAtom>(*params)->val;                                      \
@@ -39,8 +39,8 @@
   }
 
 #define MATH_DIM_OP(name, op, unaryOp)                                         \
-  SExpr *name(std::vector<SExpr *>::iterator params, const uint8_t argc,       \
-              VM &vm) {                                                        \
+  const SExpr *name(std::vector<const SExpr *>::iterator params,               \
+                    const uint8_t argc, VM &vm) {                              \
     if (argc == 1) {                                                           \
       return vm.alloc<IntAtom>(unaryOp cast<IntAtom>(*params)->val);           \
     }                                                                          \
@@ -54,16 +54,16 @@
   }
 
 #define PRED_OP(name, cond)                                                    \
-  SExpr *name(std::vector<SExpr *>::iterator params, const uint8_t argc,       \
-              VM &vm) {                                                        \
+  const SExpr *name(std::vector<const SExpr *>::iterator params,               \
+                    const uint8_t argc, VM &vm) {                              \
     return vm.alloc<BoolAtom>(cond);                                           \
   }
 
 PRED_OP(lispIsSym, isa<SymAtom>(**params));
 
 long genSymCnt = 0;
-SExpr *lispGenSym(std::vector<SExpr *>::iterator params, const uint8_t argc,
-                  VM &vm) {
+const SExpr *lispGenSym(std::vector<const SExpr *>::iterator params,
+                        const uint8_t argc, VM &vm) {
   std::stringstream ss;
   ss << ";gensym-" << genSymCnt;
   genSymCnt += 1;
@@ -80,12 +80,12 @@ MATH_CUM_OP(lispAdd, +=, 0);
 MATH_CUM_OP(lispMult, *=, 1);
 MATH_DIM_OP(lispSub, -=, 0 -);
 MATH_DIM_OP(lispDiv, /=, 1 /);
-SExpr *lispAbs(std::vector<SExpr *>::iterator params, const uint8_t argc,
-               VM &vm) {
+const SExpr *lispAbs(std::vector<const SExpr *>::iterator params,
+                     const uint8_t argc, VM &vm) {
   return vm.alloc<IntAtom>(abs(cast<IntAtom>(*params)->val));
 }
-SExpr *lispMod(std::vector<SExpr *>::iterator params, const uint8_t argc,
-               VM &vm) {
+const SExpr *lispMod(std::vector<const SExpr *>::iterator params,
+                     const uint8_t argc, VM &vm) {
   const auto lhs = cast<IntAtom>(*params)->val;
   ++params;
   const auto rhs = cast<IntAtom>(*params)->val;
@@ -93,12 +93,12 @@ SExpr *lispMod(std::vector<SExpr *>::iterator params, const uint8_t argc,
 }
 
 PRED_OP(lispIsStr, isa<StringAtom>(**params));
-SExpr *lispStrLen(std::vector<SExpr *>::iterator params, const uint8_t argc,
-                  VM &vm) {
+const SExpr *lispStrLen(std::vector<const SExpr *>::iterator params,
+                        const uint8_t argc, VM &vm) {
   return vm.alloc<IntAtom>(cast<StringAtom>(*params)->unescaped.size());
 }
-SExpr *lispStrSub(std::vector<SExpr *>::iterator params, const uint8_t argc,
-                  VM &vm) {
+const SExpr *lispStrSub(std::vector<const SExpr *>::iterator params,
+                        const uint8_t argc, VM &vm) {
   auto str = cast<StringAtom>(*params);
   auto pos = cast<IntAtom>(*(params + 1))->val;
   auto len = cast<IntAtom>(*(params + 2))->val;
@@ -113,8 +113,8 @@ SExpr *lispStrSub(std::vector<SExpr *>::iterator params, const uint8_t argc,
   }
   return vm.alloc<StringAtom>(ss.str());
 }
-SExpr *lispStrCon(std::vector<SExpr *>::iterator params, const uint8_t argc,
-                  VM &vm) {
+const SExpr *lispStrCon(std::vector<const SExpr *>::iterator params,
+                        const uint8_t argc, VM &vm) {
   std::stringstream ss;
   ss << "\"";
   for (uint8_t i{0}; i < argc; ++i) {
@@ -124,8 +124,8 @@ SExpr *lispStrCon(std::vector<SExpr *>::iterator params, const uint8_t argc,
   ss << "\"";
   return vm.alloc<StringAtom>(ss.str());
 }
-SExpr *lispToStr(std::vector<SExpr *>::iterator params, const uint8_t argc,
-                 VM &vm) {
+const SExpr *lispToStr(std::vector<const SExpr *>::iterator params,
+                       const uint8_t argc, VM &vm) {
   if (isa<StringAtom>(**params)) {
     return *params;
   }
@@ -141,27 +141,27 @@ SExpr *lispToStr(std::vector<SExpr *>::iterator params, const uint8_t argc,
 
 PRED_OP(lispIsNull, isa<NilAtom>(**params));
 PRED_OP(lispIsCons, isa<SExprs>(**params));
-SExpr *lispCons(std::vector<SExpr *>::iterator params, const uint8_t argc,
-                VM &vm) {
+const SExpr *lispCons(std::vector<const SExpr *>::iterator params,
+                      const uint8_t argc, VM &vm) {
   return vm.alloc<SExprs>(*params, *(params + 1));
 }
-SExpr *lispCar(std::vector<SExpr *>::iterator params, const uint8_t argc,
-               VM &vm) {
+const SExpr *lispCar(std::vector<const SExpr *>::iterator params,
+                     const uint8_t argc, VM &vm) {
   return cast<SExprs>(*params)->first;
 }
-SExpr *lispCdr(std::vector<SExpr *>::iterator params, const uint8_t argc,
-               VM &vm) {
+const SExpr *lispCdr(std::vector<const SExpr *>::iterator params,
+                     const uint8_t argc, VM &vm) {
   return cast<SExprs>(*params)->rest;
 }
 
-SExpr *lispDis(std::vector<SExpr *>::iterator params, const uint8_t argc,
-               VM &vm) {
+const SExpr *lispDis(std::vector<const SExpr *>::iterator params,
+                     const uint8_t argc, VM &vm) {
   cast<ClosureAtom>(*params)->dissassemble(std::cout);
   return vm.alloc<NilAtom>();
 }
-SExpr *lispDisplay(std::vector<SExpr *>::iterator params, const uint8_t argc,
-                   VM &vm) {
-  if (auto stringAtom = dynamic_cast<StringAtom *>(*params)) {
+const SExpr *lispDisplay(std::vector<const SExpr *>::iterator params,
+                         const uint8_t argc, VM &vm) {
+  if (auto stringAtom = dynamic_cast<const StringAtom *>(*params)) {
     std::cout << stringAtom->unescaped << std::endl;
   } else {
     std::cout << **params << std::endl;
@@ -169,29 +169,29 @@ SExpr *lispDisplay(std::vector<SExpr *>::iterator params, const uint8_t argc,
   return vm.alloc<NilAtom>();
 }
 
-SExpr *lispQuit(std::vector<SExpr *>::iterator params, const uint8_t argc,
-                VM &vm) {
+const SExpr *lispQuit(std::vector<const SExpr *>::iterator params,
+                      const uint8_t argc, VM &vm) {
   std::cout << "Farewell." << std::endl;
   exit(0);
 }
-SExpr *lispError(std::vector<SExpr *>::iterator params, const uint8_t argc,
-                 VM &vm) {
+const SExpr *lispError(std::vector<const SExpr *>::iterator params,
+                       const uint8_t argc, VM &vm) {
   std::stringstream ss;
   ss << **params;
   throw std::runtime_error(ss.str());
 }
 
-SExpr *lispEq(std::vector<SExpr *>::iterator params, const uint8_t argc,
-              VM &vm) {
+const SExpr *lispEq(std::vector<const SExpr *>::iterator params,
+                    const uint8_t argc, VM &vm) {
   return vm.alloc<BoolAtom>((*params) == (*(params + 1)));
 }
-SExpr *lispEqv(std::vector<SExpr *>::iterator params, const uint8_t argc,
-               VM &vm) {
+const SExpr *lispEqv(std::vector<const SExpr *>::iterator params,
+                     const uint8_t argc, VM &vm) {
   return vm.alloc<BoolAtom>(**params == **(params + 1));
 }
 
-SExpr *lispIsProc(std::vector<SExpr *>::iterator params, const uint8_t argc,
-                  VM &vm) {
+const SExpr *lispIsProc(std::vector<const SExpr *>::iterator params,
+                        const uint8_t argc, VM &vm) {
   return vm.alloc<BoolAtom>(isa<ClosureAtom>(**params) ||
                             isa<NatFnAtom>(**params));
 }

--- a/src/runtime/NatFnImpls.hpp
+++ b/src/runtime/NatFnImpls.hpp
@@ -6,8 +6,8 @@
 #include <memory>
 #include <vector>
 
-typedef SExpr *(NativeFn)(std::vector<SExpr *>::iterator params,
-                          const uint8_t argc, VM &vm);
+typedef const SExpr *(NativeFn)(std::vector<const SExpr *>::iterator params,
+                                const uint8_t argc, VM &vm);
 
 NativeFn lispIsSym;
 NativeFn lispGenSym;

--- a/src/runtime/NatFnImpls.hpp
+++ b/src/runtime/NatFnImpls.hpp
@@ -2,11 +2,12 @@
 #define LISP_SRC_VM_NATIVEFNS_HPP_
 
 #include "../common/sexpr/SExpr.hpp"
+#include "../runtime/VM.hpp"
 #include <memory>
 #include <vector>
 
-typedef std::shared_ptr<SExpr>(NativeFn)(
-    std::vector<std::shared_ptr<SExpr>>::iterator params, const uint8_t argc);
+typedef SExpr *(NativeFn)(std::vector<SExpr *>::iterator params,
+                          const uint8_t argc, VM &vm);
 
 NativeFn lispIsSym;
 NativeFn lispGenSym;

--- a/src/runtime/RuntimeError.cpp
+++ b/src/runtime/RuntimeError.cpp
@@ -1,0 +1,48 @@
+#include "RuntimeError.hpp"
+#include <iomanip>
+
+RuntimeError::RuntimeError(const std::string &msg, Env globals,
+                           std::vector<const SExpr *> stack,
+                           std::vector<VM::CallFrame> frames)
+    : _msg(msg), globals(globals), stack(stack), frames(frames) {}
+
+const char *RuntimeError::what() const noexcept { return _msg.c_str(); }
+
+std::ostream &operator<<(std::ostream &o, const RuntimeError &re) {
+  std::unordered_map<const SExpr *, const SymAtom *> sExprSyms;
+  for (const auto &p : re.globals.getSymTable()) {
+    sExprSyms.insert({p.second, p.first});
+  }
+
+  const unsigned int PADDING_WIDTH = 4;
+  const unsigned int IDX_WIDTH = 8;
+
+  o << "In code object with ip: " << re.frames.back().ip << std::endl;
+
+  o << std::setw(PADDING_WIDTH) << std::right
+    << re.frames.back().closure->fnAtom->code << "Call stack:";
+  for (unsigned int idx = 0; const auto &stackFrame : re.frames) {
+    o << std::endl
+      << std::setw(PADDING_WIDTH) << "" << std::setw(IDX_WIDTH) << std::left
+      << idx << "<Closure: " << stackFrame.closure << ", ip: " << stackFrame.ip
+      << ", bp: " << stackFrame.bp << ">";
+    idx += 1;
+    auto it = sExprSyms.find(stackFrame.closure);
+    if (it != sExprSyms.end()) {
+      o << " (" << *it->second << ")";
+    }
+  }
+
+  o << std::endl << "Data stack:";
+  for (unsigned int idx = 0; const auto &sexpr : re.stack) {
+    o << std::endl
+      << std::setw(PADDING_WIDTH) << "" << std::setw(IDX_WIDTH) << std::left
+      << idx << *sexpr;
+    idx += 1;
+    auto it = sExprSyms.find(sexpr);
+    if (it != sExprSyms.end()) {
+      o << " (" << it->second << ")";
+    }
+  }
+  return o << std::endl << re.what();
+}

--- a/src/runtime/RuntimeError.hpp
+++ b/src/runtime/RuntimeError.hpp
@@ -1,0 +1,28 @@
+#ifndef LISP_SRC_VM_RUNTIMEERROR_HPP_
+#define LISP_SRC_VM_RUNTIMEERROR_HPP_
+
+#include "Env.hpp"
+#include "VM.hpp"
+#include <exception>
+#include <ostream>
+
+class RuntimeError : public std::exception {
+  friend std::ostream &operator<<(std::ostream &o, const RuntimeError &re);
+
+private:
+  std::string _msg;
+  const Env globals;
+  const std::vector<const SExpr *> stack;
+  const std::vector<VM::CallFrame> frames;
+
+public:
+  RuntimeError(const std::string &msg, Env globals,
+               std::vector<const SExpr *> stack,
+               std::vector<VM::CallFrame> frames);
+
+  virtual const char *what() const noexcept override;
+};
+
+std::ostream &operator<<(std::ostream &o, const RuntimeError &re);
+
+#endif

--- a/src/runtime/Upvalue.cpp
+++ b/src/runtime/Upvalue.cpp
@@ -2,7 +2,7 @@
 
 Upvalue::Upvalue(const std::vector<SExpr *>::size_type stackPos,
                  std::vector<SExpr *> &stack)
-    : stackPos(stackPos), stack(stack) {}
+    : stackPos(stackPos), stack(stack), value(nullptr) {}
 
 bool Upvalue::isOpen() const { return value == nullptr; }
 
@@ -15,7 +15,7 @@ SExpr *Upvalue::get() const {
   return value;
 }
 
-void Upvalue::set(SExpr *&sexpr) {
+void Upvalue::set(SExpr *sexpr) {
   if (isOpen()) {
     stack[stackPos] = sexpr;
   }

--- a/src/runtime/Upvalue.cpp
+++ b/src/runtime/Upvalue.cpp
@@ -1,21 +1,21 @@
 #include "Upvalue.hpp"
 
-Upvalue::Upvalue(const std::vector<SExpr *>::size_type stackPos,
-                 std::vector<SExpr *> &stack)
+Upvalue::Upvalue(const std::vector<const SExpr *>::size_type stackPos,
+                 std::vector<const SExpr *> &stack)
     : stackPos(stackPos), stack(stack), value(nullptr) {}
 
 bool Upvalue::isOpen() const { return value == nullptr; }
 
 void Upvalue::close() { value = std::move(stack[stackPos]); }
 
-SExpr *Upvalue::get() const {
+const SExpr *Upvalue::get() const {
   if (isOpen()) {
     return stack[stackPos];
   }
   return value;
 }
 
-void Upvalue::set(SExpr *sexpr) {
+void Upvalue::set(const SExpr *sexpr) {
   if (isOpen()) {
     stack[stackPos] = sexpr;
   }

--- a/src/runtime/Upvalue.cpp
+++ b/src/runtime/Upvalue.cpp
@@ -1,21 +1,21 @@
 #include "Upvalue.hpp"
 
-Upvalue::Upvalue(const std::vector<std::shared_ptr<SExpr>>::size_type stackPos,
-                 std::vector<std::shared_ptr<SExpr>> &stack)
+Upvalue::Upvalue(const std::vector<SExpr *>::size_type stackPos,
+                 std::vector<SExpr *> &stack)
     : stackPos(stackPos), stack(stack) {}
 
 bool Upvalue::isOpen() const { return value == nullptr; }
 
 void Upvalue::close() { value = std::move(stack[stackPos]); }
 
-std::shared_ptr<SExpr> Upvalue::get() const {
+SExpr *Upvalue::get() const {
   if (isOpen()) {
     return stack[stackPos];
   }
   return value;
 }
 
-void Upvalue::set(std::shared_ptr<SExpr> &sexpr) {
+void Upvalue::set(SExpr *&sexpr) {
   if (isOpen()) {
     stack[stackPos] = sexpr;
   }

--- a/src/runtime/Upvalue.hpp
+++ b/src/runtime/Upvalue.hpp
@@ -23,7 +23,7 @@ public:
   void close();
 
   SExpr *get() const;
-  void set(SExpr *&sexpr);
+  void set(SExpr *sexpr);
 };
 
 #endif

--- a/src/runtime/Upvalue.hpp
+++ b/src/runtime/Upvalue.hpp
@@ -9,21 +9,21 @@ class Upvalue {
   friend bool operator==(const Upvalue &lhs, const Upvalue &rhs);
 
 private:
-  const std::vector<std::shared_ptr<SExpr>>::size_type stackPos;
-  std::vector<std::shared_ptr<SExpr>> &stack;
+  const std::vector<SExpr *>::size_type stackPos;
+  std::vector<SExpr *> &stack;
 
-  std::shared_ptr<SExpr> value;
+  SExpr *value;
 
   bool isOpen() const;
 
 public:
-  Upvalue(const std::vector<std::shared_ptr<SExpr>>::size_type stackPos,
-          std::vector<std::shared_ptr<SExpr>> &stack);
+  Upvalue(const std::vector<SExpr *>::size_type stackPos,
+          std::vector<SExpr *> &stack);
 
   void close();
 
-  std::shared_ptr<SExpr> get() const;
-  void set(std::shared_ptr<SExpr> &sexpr);
+  SExpr *get() const;
+  void set(SExpr *&sexpr);
 };
 
 #endif

--- a/src/runtime/Upvalue.hpp
+++ b/src/runtime/Upvalue.hpp
@@ -9,21 +9,21 @@ class Upvalue {
   friend bool operator==(const Upvalue &lhs, const Upvalue &rhs);
 
 private:
-  const std::vector<SExpr *>::size_type stackPos;
-  std::vector<SExpr *> &stack;
+  const std::vector<const SExpr *>::size_type stackPos;
+  std::vector<const SExpr *> &stack;
 
-  SExpr *value;
+  const SExpr *value;
 
   bool isOpen() const;
 
 public:
-  Upvalue(const std::vector<SExpr *>::size_type stackPos,
-          std::vector<SExpr *> &stack);
+  Upvalue(const std::vector<const SExpr *>::size_type stackPos,
+          std::vector<const SExpr *> &stack);
 
   void close();
 
-  SExpr *get() const;
-  void set(SExpr *sexpr);
+  const SExpr *get() const;
+  void set(const SExpr *sexpr);
 };
 
 #endif

--- a/src/runtime/VM.cpp
+++ b/src/runtime/VM.cpp
@@ -50,10 +50,7 @@ const SExpr *VM::exec(const FnAtom *main) {
 
 #define GC_ATOMIC(stmts)                                                       \
   do {                                                                         \
-    const auto gcSetting = enableGC;                                           \
-    enableGC = false;                                                          \
-    stmts;                                                                     \
-    enableGC = gcSetting;                                                      \
+                                                                               \
   } while (false)
 
   static void *dispatchTable[] = {
@@ -152,9 +149,16 @@ POP_JUMP_IF_FALSE : {
   DISPATCH();
 }
 MAKE_LIST : {
-  GC_ATOMIC(const auto n = stack.size() - BASE_PTR() - 1;
-            const auto list = makeList(n); stack.resize(stack.size() - n);
-            stack.push_back(list););
+  const auto gcSetting = enableGC;
+  enableGC = false;
+
+  const auto n = stack.size() - BASE_PTR() - 1;
+
+  const auto list = makeList(n);
+  stack.erase(stack.end() - n, stack.end());
+  stack.push_back(list);
+
+  enableGC = gcSetting;
   DISPATCH();
 }
 

--- a/src/runtime/VM.cpp
+++ b/src/runtime/VM.cpp
@@ -7,6 +7,7 @@
 #include "../common/sexpr/SExprs.hpp"
 #include "RuntimeError.hpp"
 #include "Upvalue.hpp"
+#include <algorithm>
 #include <exception>
 #include <iomanip>
 #include <iterator>
@@ -16,7 +17,24 @@
 #include <unordered_map>
 #include <vector>
 
-const SExpr *VM::interp(const FnAtom *main) {
+const SExpr *VM::eval(const FnAtom *main, bool withGC) {
+  try {
+    stack.push_back(alloc<ClosureAtom>(main));
+
+    enableGC = withGC;
+
+    return exec(main);
+  } catch (std::exception &e) {
+    std::stringstream ss;
+    ss << "Runtime error: " << e.what();
+    const auto re = RuntimeError(ss.str(), globals, stack, callFrames);
+    reset();
+    throw re;
+  }
+  return nullptr;
+}
+
+const SExpr *VM::exec(const FnAtom *main) {
 #define CUR_CALL_FRAME() (callFrames.back())
 #define CUR_CLOSURE() (CUR_CALL_FRAME().closure)
 #define CUR_FN() (CUR_CLOSURE()->fnAtom)
@@ -32,13 +50,20 @@ const SExpr *VM::interp(const FnAtom *main) {
 
 #define DISPATCH() goto *dispatchTable[READ_BYTE()]
 
+#define GC_ATOMIC(stmts)                                                       \
+  do {                                                                         \
+    const auto gcSetting = enableGC;                                           \
+    enableGC = false;                                                          \
+    stmts;                                                                     \
+    enableGC = gcSetting;                                                      \
+  } while (false)
+
   static void *dispatchTable[] = {
       &&MAKE_CLOSURE, &&CALL,       &&RETURN,    &&POP_TOP, &&CLOSE_UPVALUE,
       &&LOAD_CONST,   &&LOAD_SYM,   &&DEF_SYM,   &&SET_SYM, &&LOAD_UPVALUE,
       &&SET_UPVALUE,  &&LOAD_STACK, &&SET_STACK, &&JUMP,    &&POP_JUMP_IF_FALSE,
       &&MAKE_LIST};
 
-  stack.push_back(alloc<ClosureAtom>(main));
   call(0);
 
   DISPATCH();
@@ -65,8 +90,7 @@ CALL : {
 RETURN : {
   if (callFrames.size() == 1) {
     const auto res = stack.back();
-    callFrames.clear();
-    stack.clear();
+    reset();
     return res;
   }
   callFrames.pop_back();
@@ -130,10 +154,9 @@ POP_JUMP_IF_FALSE : {
   DISPATCH();
 }
 MAKE_LIST : {
-  const auto n = stack.size() - BASE_PTR() - 1;
-  const auto list = makeList(n);
-  stack.resize(stack.size() - n);
-  stack.push_back(list);
+  GC_ATOMIC(const auto n = stack.size() - BASE_PTR() - 1;
+            const auto list = makeList(n); stack.resize(stack.size() - n);
+            stack.push_back(list););
   DISPATCH();
 }
 
@@ -161,9 +184,7 @@ void VM::call(const uint8_t argc) {
   }
   const auto res =
       cast<NatFnAtom>(callee)->invoke(stack.end() - argc, argc, *this);
-  for (uint8_t i{0}; i < argc + 1; ++i) {
-    stack.pop_back();
-  }
+  stack.erase(stack.end() - argc - 1, stack.end());
   stack.push_back(res);
   return;
 }
@@ -189,7 +210,83 @@ const SExpr *VM::makeList(const std::vector<const SExpr *>::size_type n) {
   return alloc<SExprs>(*(stack.end() - n), makeList(n - 1));
 }
 
-VM::VM() {
+void VM::gc() {
+  black.clear();
+
+  markGlobals();
+  markStack();
+  markCallFrames();
+  markOpenUpvalues();
+
+  while (grey.size() > 0) {
+    const auto sexpr = *grey.begin();
+    black.emplace(sexpr);
+    grey.erase(grey.begin());
+    trace(sexpr);
+  }
+  std::erase_if(
+      heap, [&](const auto &unique) { return !black.contains(unique.get()); });
+}
+
+void VM::mark(const SExpr *sexpr) {
+  if (!black.contains(sexpr)) {
+    grey.emplace(sexpr);
+  }
+}
+
+void VM::trace(const SExpr *sexpr) {
+  if (const auto sexprs = dynamic_cast<const SExprs *>(sexpr)) {
+    mark(sexprs->first);
+    mark(sexprs->rest);
+    return;
+  }
+  if (const auto fnAtom = dynamic_cast<const FnAtom *>(sexpr)) {
+    std::for_each(fnAtom->code.consts.begin(), fnAtom->code.consts.end(),
+                  [&](const SExpr *sexpr) { mark(sexpr); });
+    return;
+  }
+  if (const auto closureAtom = dynamic_cast<const ClosureAtom *>(sexpr)) {
+    mark(closureAtom->fnAtom);
+    std::for_each(
+        closureAtom->upvalues.begin(), closureAtom->upvalues.end(),
+        [&](const std::shared_ptr<Upvalue> upvalue) { mark(upvalue->get()); });
+    return;
+  }
+}
+
+void VM::markGlobals() {
+  for (const auto &[sym, sexpr] : globals.symTable) {
+    grey.emplace(sym);
+    grey.emplace(sexpr);
+  }
+}
+void VM::markStack() {
+  for (const auto &sexpr : stack) {
+    grey.emplace(sexpr);
+  }
+}
+void VM::markCallFrames() {
+  for (const auto &callFrame : callFrames) {
+    grey.emplace(callFrame.closure);
+  }
+}
+void VM::markOpenUpvalues() {
+  for (const auto &[_, openUpvalue] : openUpvalues) {
+    grey.emplace(openUpvalue->get());
+  }
+}
+
+void VM::reset() {
+  stack.clear();
+  callFrames.clear();
+  enableGC = false;
+}
+
+VM::VM() : enableGC(false), gcHeapSize(LISP_GC_INIT_HEAP_SIZE) {
+  for (int i{LISP_INT_CACHE_MIN}; i <= LISP_INT_CACHE_MAX; i++) {
+    intCache.push_back(std::make_unique<IntAtom>(i));
+  }
+
 #define BIND_NATIVE_FN(sym, func, argc)                                        \
   do {                                                                         \
     globals.def(alloc<SymAtom>(sym), alloc<NatFnAtom>(&func, argc));           \
@@ -237,18 +334,14 @@ VM::VM() {
 #undef BIND_NATIVE_FN
 }
 
-const SExpr *VM::exec(const FnAtom *main) {
-  try {
-    return interp(main);
-  } catch (std::exception &e) {
-    std::stringstream ss;
-    ss << "Runtime error: " << e.what();
-    const auto re = RuntimeError(ss.str(), globals, stack, callFrames);
-    stack.clear();
-    callFrames.clear();
-    throw re;
-  }
-  return nullptr;
+const SExpr *VM::eval(const FnAtom *main) {
+  const auto res = eval(main, false);
+  return res;
+}
+
+const SExpr *VM::evalWithGC(const FnAtom *main) {
+  const auto res = eval(main, true);
+  return res;
 }
 
 void VM::defMacro(const SymAtom *sym) { globals.defMacro(sym); }

--- a/src/runtime/VM.cpp
+++ b/src/runtime/VM.cpp
@@ -89,15 +89,15 @@ LOAD_CONST : {
   DISPATCH();
 }
 LOAD_SYM : {
-  stack.push_back(globals.find(*cast<SymAtom>(READ_CONST())));
+  stack.push_back(globals.find(cast<SymAtom>(READ_CONST())));
   DISPATCH();
 }
 DEF_SYM : {
-  globals.def(*cast<SymAtom>(READ_CONST()), stack.back());
+  globals.def(cast<SymAtom>(READ_CONST()), stack.back());
   DISPATCH();
 }
 SET_SYM : {
-  globals.set(*cast<SymAtom>(READ_CONST()), stack.back());
+  globals.set(cast<SymAtom>(READ_CONST()), stack.back());
   DISPATCH();
 }
 LOAD_UPVALUE : {
@@ -205,7 +205,7 @@ SExprs *VM::makeList(const std::vector<SExpr *>::size_type n) {
 VM::VM() {
 #define BIND_NATIVE_FN(sym, func, argc)                                        \
   do {                                                                         \
-    globals.def(*alloc<SymAtom>(sym), alloc<NatFnAtom>(&func, argc));          \
+    globals.def(alloc<SymAtom>(sym), alloc<NatFnAtom>(&func, argc));           \
   } while (false)
 
   BIND_NATIVE_FN("sym?", lispIsSym, 1);
@@ -272,7 +272,7 @@ VM::RuntimeException::RuntimeException(const std::string &msg, Env globals,
 const char *VM::RuntimeException::what() const noexcept { return _msg.c_str(); }
 
 std::ostream &operator<<(std::ostream &o, const VM::RuntimeException &re) {
-  std::unordered_map<SExpr *, SymAtom> sExprSyms;
+  std::unordered_map<SExpr *, SymAtom *> sExprSyms;
   for (const auto &p : re.globals.getSymTable()) {
     sExprSyms.insert({p.second, p.first});
   }
@@ -292,7 +292,7 @@ std::ostream &operator<<(std::ostream &o, const VM::RuntimeException &re) {
     idx += 1;
     auto it = sExprSyms.find(stackFrame.closure);
     if (it != sExprSyms.end()) {
-      o << " (" << it->second << ")";
+      o << " (" << *it->second << ")";
     }
   }
 
@@ -310,6 +310,6 @@ std::ostream &operator<<(std::ostream &o, const VM::RuntimeException &re) {
   return o << std::endl << re.what();
 }
 
-void VM::defMacro(SymAtom &sym) { globals.defMacro(sym); }
+void VM::defMacro(SymAtom *sym) { globals.defMacro(sym); }
 
-bool VM::isMacro(SymAtom &sym) { return globals.isMacro(sym); }
+bool VM::isMacro(SymAtom *sym) { return globals.isMacro(sym); }

--- a/src/runtime/VM.cpp
+++ b/src/runtime/VM.cpp
@@ -235,17 +235,20 @@ void VM::mark(const SExpr *sexpr) {
 }
 
 void VM::trace(const SExpr *sexpr) {
-  if (const auto sexprs = dynamic_cast<const SExprs *>(sexpr)) {
+  if (isa<SExprs>(sexpr)) {
+    const auto sexprs = dynamic_cast<const SExprs *>(sexpr);
     mark(sexprs->first);
     mark(sexprs->rest);
     return;
   }
-  if (const auto fnAtom = dynamic_cast<const FnAtom *>(sexpr)) {
+  if (isa<FnAtom>(sexpr)) {
+    const auto fnAtom = dynamic_cast<const FnAtom *>(sexpr);
     std::for_each(fnAtom->code.consts.begin(), fnAtom->code.consts.end(),
                   [&](const SExpr *sexpr) { mark(sexpr); });
     return;
   }
-  if (const auto closureAtom = dynamic_cast<const ClosureAtom *>(sexpr)) {
+  if (isa<ClosureAtom>(sexpr)) {
+    const auto closureAtom = dynamic_cast<const ClosureAtom *>(sexpr);
     mark(closureAtom->fnAtom);
     std::for_each(
         closureAtom->upvalues.begin(), closureAtom->upvalues.end(),

--- a/src/runtime/VM.cpp
+++ b/src/runtime/VM.cpp
@@ -154,7 +154,7 @@ MAKE_LIST : {
 
 void VM::call(const uint8_t argc) {
   const auto callee = peak(argc);
-  if (isa<ClosureAtom>(*callee)) {
+  if (isa<ClosureAtom>(callee)) {
     const auto closure = cast<ClosureAtom>(callee);
     closure->assertArity(argc);
     frames.push_back({closure, 0, stack.size() - argc - 1});

--- a/src/runtime/VM.cpp
+++ b/src/runtime/VM.cpp
@@ -255,7 +255,7 @@ void VM::trace(const SExpr *sexpr) {
 }
 
 void VM::markGlobals() {
-  for (const auto &[sym, sexpr] : globals.symTable) {
+  for (const auto &[sym, sexpr] : globals.getSymTable()) {
     grey.emplace(sym);
     grey.emplace(sexpr);
   }

--- a/src/runtime/VM.cpp
+++ b/src/runtime/VM.cpp
@@ -45,7 +45,7 @@ SExpr *VM::interp(FnAtom *main) {
 
 MAKE_CLOSURE : {
   const auto closure = alloc<ClosureAtom>(cast<FnAtom>(READ_CONST()));
-  for (unsigned int i{0}; i < closure->fnAtom->numUpVals; ++i) {
+  for (unsigned int i{0}; i < closure->fnAtom->numUpvals; ++i) {
     auto isLocal = READ_BYTE();
     auto idx = READ_BYTE();
     if (isLocal == 1) {

--- a/src/runtime/VM.cpp
+++ b/src/runtime/VM.cpp
@@ -130,15 +130,9 @@ POP_JUMP_IF_FALSE : {
 }
 MAKE_LIST : {
   const auto n = stack.size() - BASE_PTR() - 1;
-  if (n == 0) {
-    stack.push_back(alloc<NilAtom>());
-  } else {
-    const auto list = makeList(n);
-    for (std::vector<SExpr *>::size_type i{0}; i < n; ++i) {
-      stack.pop_back();
-    }
-    stack.push_back(std::move(list));
-  }
+  const auto list = makeList(n);
+  stack.resize(stack.size() - n);
+  stack.push_back(list);
   DISPATCH();
 }
 
@@ -187,19 +181,11 @@ SExpr *VM::peak(std::vector<SExpr *>::size_type distance) {
   return stack.rbegin()[distance];
 }
 
-SExprs *VM::makeList(const std::vector<SExpr *>::size_type n) {
-  auto list = alloc<SExprs>();
-  auto cur = list;
-  for (auto i = stack.end() - n; i != stack.end(); ++i) {
-    cur->first = *i;
-    if (i != stack.end() - 1) {
-      cur->rest = alloc<SExprs>();
-      cur = cast<SExprs>(cur->rest);
-    } else {
-      cur->rest = alloc<NilAtom>();
-    }
+SExpr *VM::makeList(const std::vector<SExpr *>::size_type n) {
+  if (n == 0) {
+    return alloc<NilAtom>();
   }
-  return list;
+  return alloc<SExprs>(*(stack.end() - n), makeList(n - 1));
 }
 
 VM::VM() {

--- a/src/runtime/VM.cpp
+++ b/src/runtime/VM.cpp
@@ -10,7 +10,6 @@
 #include <algorithm>
 #include <exception>
 #include <iomanip>
-#include <iterator>
 #include <memory>
 #include <sstream>
 #include <string>

--- a/src/runtime/VM.cpp
+++ b/src/runtime/VM.cpp
@@ -14,7 +14,6 @@
 #include <memory>
 #include <sstream>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 const SExpr *VM::eval(const FnAtom *main, bool withGC) {
@@ -235,20 +234,17 @@ void VM::mark(const SExpr *sexpr) {
 }
 
 void VM::trace(const SExpr *sexpr) {
-  if (isa<SExprs>(sexpr)) {
-    const auto sexprs = dynamic_cast<const SExprs *>(sexpr);
+  if (const auto sexprs = dynCast<SExprs>(sexpr)) {
     mark(sexprs->first);
     mark(sexprs->rest);
     return;
   }
-  if (isa<FnAtom>(sexpr)) {
-    const auto fnAtom = dynamic_cast<const FnAtom *>(sexpr);
+  if (const auto fnAtom = dynCast<FnAtom>(sexpr)) {
     std::for_each(fnAtom->code.consts.begin(), fnAtom->code.consts.end(),
                   [&](const SExpr *sexpr) { mark(sexpr); });
     return;
   }
-  if (isa<ClosureAtom>(sexpr)) {
-    const auto closureAtom = dynamic_cast<const ClosureAtom *>(sexpr);
+  if (const auto closureAtom = dynCast<ClosureAtom>(sexpr)) {
     mark(closureAtom->fnAtom);
     std::for_each(
         closureAtom->upvalues.begin(), closureAtom->upvalues.end(),

--- a/src/runtime/VM.hpp
+++ b/src/runtime/VM.hpp
@@ -1,14 +1,21 @@
 #ifndef LISP_SRC_VM_VM_HPP_
 #define LISP_SRC_VM_VM_HPP_
 
+#define LISP_GC_HEAP_GROWTH_FACTOR 2
+#define LISP_GC_INIT_HEAP_SIZE 4096
+#define LISP_INT_CACHE_MAX 256
+#define LISP_INT_CACHE_MIN -16
+
 #include "../common/sexpr/BoolAtom.hpp"
 #include "../common/sexpr/ClosureAtom.hpp"
+#include "../common/sexpr/IntAtom.hpp"
 #include "../common/sexpr/NilAtom.hpp"
 #include "../common/sexpr/SExpr.hpp"
 #include "Env.hpp"
 #include "Upvalue.hpp"
 #include <memory>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 class VM {
@@ -21,8 +28,6 @@ private:
     std::vector<const SExpr *>::size_type bp;
   };
 
-  std::vector<std::unique_ptr<const SExpr>> heap;
-
   Env globals;
 
   std::vector<const SExpr *> stack;
@@ -31,31 +36,70 @@ private:
                      std::shared_ptr<Upvalue>>
       openUpvalues;
 
-  void call(const uint8_t argc);
+  bool enableGC;
+  size_t gcHeapSize;
 
-  const SExpr *interp(const FnAtom *main);
+  std::unordered_set<std::unique_ptr<const SExpr>> heap;
+
+  std::unordered_set<const SExpr *> black;
+  std::unordered_set<const SExpr *> grey;
+  std::vector<std::unique_ptr<const IntAtom>> intCache;
+
+  const SExpr *eval(const FnAtom *main, bool withGC);
+  const SExpr *exec(const FnAtom *main);
+
+  void call(const uint8_t argc);
 
   std::shared_ptr<Upvalue>
   captureUpvalue(std::vector<const SExpr *>::size_type pos);
   const SExpr *peak(std::vector<const SExpr *>::size_type distance);
   const SExpr *makeList(std::vector<const SExpr *>::size_type size);
 
+  void gc();
+
+  void mark(const SExpr *sexpr);
+  void trace(const SExpr *sexpr);
+
+  void markGlobals();
+  void markStack();
+  void markCallFrames();
+  void markOpenUpvalues();
+
+  void reset();
+
 public:
   VM();
-  const SExpr *exec(const FnAtom *main);
+
+  const SExpr *evalWithGC(const FnAtom *main);
+  const SExpr *eval(const FnAtom *main);
 
   void defMacro(const SymAtom *sym);
   bool isMacro(const SymAtom *sym);
 
   template <typename T, typename... Args> const T *alloc(Args &&...args) {
-    heap.emplace_back(std::make_unique<const T>(std::forward<Args>(args)...));
-    return static_cast<const T *>(heap.back().get());
+    if (enableGC && heap.size() > gcHeapSize) {
+      gc();
+      gcHeapSize = heap.size() * LISP_GC_HEAP_GROWTH_FACTOR;
+    }
+    auto unique = std::make_unique<const T>(std::forward<Args>(args)...);
+    const auto ptr = unique.get();
+    heap.emplace(std::move(unique));
+    return static_cast<const T *>(ptr);
   }
 };
 
 template <> inline const NilAtom *VM::alloc() { return NilAtom::getInstance(); }
 template <> inline const BoolAtom *VM::alloc(bool &&val) {
   return BoolAtom::getInstance(val);
+}
+template <> inline const IntAtom *VM::alloc(int &&val) {
+  if (val >= LISP_INT_CACHE_MIN && val <= LISP_INT_CACHE_MAX) {
+    return intCache.at(val - LISP_INT_CACHE_MIN).get();
+  }
+  auto unique = std::make_unique<const IntAtom>(val);
+  const auto ptr = unique.get();
+  heap.emplace(std::move(unique));
+  return ptr;
 }
 
 #endif

--- a/src/runtime/VM.hpp
+++ b/src/runtime/VM.hpp
@@ -1,6 +1,7 @@
 #ifndef LISP_SRC_VM_VM_HPP_
 #define LISP_SRC_VM_VM_HPP_
 
+#include "../common/sexpr/BoolAtom.hpp"
 #include "../common/sexpr/ClosureAtom.hpp"
 #include "../common/sexpr/NilAtom.hpp"
 #include "../common/sexpr/SExpr.hpp"
@@ -66,6 +67,9 @@ public:
 };
 
 template <> inline NilAtom *VM::alloc() { return NilAtom::getInstance(); }
+template <> inline BoolAtom *VM::alloc(bool &&val) {
+  return BoolAtom::getInstance(val);
+}
 
 std::ostream &operator<<(std::ostream &o, const VM::RuntimeException &re);
 

--- a/src/runtime/VM.hpp
+++ b/src/runtime/VM.hpp
@@ -21,6 +21,7 @@ private:
   Env globals;
   std::vector<SExpr *> stack;
   std::vector<std::unique_ptr<SExpr>> heap;
+  std::unordered_map<int, SExpr *> integers;
   std::vector<CallFrame> frames;
   std::unordered_map<std::vector<SExpr *>::size_type, std::shared_ptr<Upvalue>>
       openUpvalues;
@@ -54,8 +55,8 @@ public:
   VM();
   SExpr *exec(FnAtom *main);
 
-  void defMacro(SymAtom &sym);
-  bool isMacro(SymAtom &sym);
+  void defMacro(SymAtom *sym);
+  bool isMacro(SymAtom *sym);
 
   template <typename T, typename... Args> T *alloc(Args &&...args) {
     heap.emplace_back(std::make_unique<T>(std::forward<Args>(args)...));

--- a/src/runtime/VM.hpp
+++ b/src/runtime/VM.hpp
@@ -34,7 +34,7 @@ private:
 
   std::shared_ptr<Upvalue> captureUpvalue(std::vector<SExpr *>::size_type pos);
   SExpr *peak(std::vector<SExpr *>::size_type distance);
-  SExprs *makeList(std::vector<SExpr *>::size_type size);
+  SExpr *makeList(std::vector<SExpr *>::size_type size);
 
 public:
   class RuntimeException : public std::exception {

--- a/src/runtime/VM.hpp
+++ b/src/runtime/VM.hpp
@@ -21,18 +21,19 @@ private:
     std::vector<const SExpr *>::size_type bp;
   };
 
-  Env globals;
-  std::vector<const SExpr *> stack;
   std::vector<std::unique_ptr<const SExpr>> heap;
-  std::unordered_map<int, const SExpr *> integers;
-  std::vector<CallFrame> frames;
+
+  Env globals;
+
+  std::vector<const SExpr *> stack;
+  std::vector<CallFrame> callFrames;
   std::unordered_map<std::vector<const SExpr *>::size_type,
                      std::shared_ptr<Upvalue>>
       openUpvalues;
 
-  const SExpr *interp(const FnAtom *main);
-
   void call(const uint8_t argc);
+
+  const SExpr *interp(const FnAtom *main);
 
   std::shared_ptr<Upvalue>
   captureUpvalue(std::vector<const SExpr *>::size_type pos);

--- a/src/runtime/VM.hpp
+++ b/src/runtime/VM.hpp
@@ -39,7 +39,7 @@ private:
   bool enableGC;
   size_t gcHeapSize;
 
-  std::unordered_set<std::unique_ptr<const SExpr>> heap;
+  std::vector<std::unique_ptr<const SExpr>> heap;
 
   std::unordered_set<const SExpr *> black;
   std::unordered_set<const SExpr *> grey;
@@ -81,10 +81,8 @@ public:
       gc();
       gcHeapSize = heap.size() * LISP_GC_HEAP_GROWTH_FACTOR;
     }
-    auto unique = std::make_unique<const T>(std::forward<Args>(args)...);
-    const auto ptr = unique.get();
-    heap.emplace(std::move(unique));
-    return static_cast<const T *>(ptr);
+    heap.emplace_back(std::make_unique<const T>(std::forward<Args>(args)...));
+    return static_cast<const T *>(heap.back().get());
   }
 };
 
@@ -96,10 +94,8 @@ template <> inline const IntAtom *VM::alloc(int &&val) {
   if (val >= LISP_INT_CACHE_MIN && val <= LISP_INT_CACHE_MAX) {
     return intCache.at(val - LISP_INT_CACHE_MIN).get();
   }
-  auto unique = std::make_unique<const IntAtom>(val);
-  const auto ptr = unique.get();
-  heap.emplace(std::move(unique));
-  return ptr;
+  heap.emplace_back(std::make_unique<const IntAtom>(val));
+  return static_cast<const IntAtom *>(heap.back().get());
 }
 
 #endif

--- a/src/runtime/VM.hpp
+++ b/src/runtime/VM.hpp
@@ -81,8 +81,10 @@ public:
       gc();
       gcHeapSize = heap.size() * LISP_GC_HEAP_GROWTH_FACTOR;
     }
-    heap.emplace_back(std::make_unique<const T>(std::forward<Args>(args)...));
-    return static_cast<const T *>(heap.back().get());
+    auto unique = std::make_unique<const T>(std::forward<Args>(args)...);
+    const auto ptr = unique.get();
+    heap.emplace_back(std::move(unique));
+    return ptr;
   }
 };
 
@@ -94,8 +96,10 @@ template <> inline const IntAtom *VM::alloc(int &&val) {
   if (val >= LISP_INT_CACHE_MIN && val <= LISP_INT_CACHE_MAX) {
     return intCache.at(val - LISP_INT_CACHE_MIN).get();
   }
-  heap.emplace_back(std::make_unique<const IntAtom>(val));
-  return static_cast<const IntAtom *>(heap.back().get());
+  auto unique = std::make_unique<const IntAtom>(val);
+  const auto ptr = unique.get();
+  heap.emplace_back(std::move(unique));
+  return ptr;
 }
 
 #endif

--- a/src/runtime/VM.hpp
+++ b/src/runtime/VM.hpp
@@ -2,6 +2,7 @@
 #define LISP_SRC_VM_VM_HPP_
 
 #include "../common/sexpr/ClosureAtom.hpp"
+#include "../common/sexpr/NilAtom.hpp"
 #include "../common/sexpr/SExpr.hpp"
 #include "../common/sexpr/SExprs.hpp"
 #include "Env.hpp"
@@ -63,6 +64,8 @@ public:
     return static_cast<T *>(heap.back().get());
   }
 };
+
+template <> inline NilAtom *VM::alloc() { return NilAtom::getInstance(); }
 
 std::ostream &operator<<(std::ostream &o, const VM::RuntimeException &re);
 

--- a/src/runtime/VM.hpp
+++ b/src/runtime/VM.hpp
@@ -12,6 +12,8 @@
 #include <vector>
 
 class VM {
+  friend class RuntimeError;
+
 private:
   struct CallFrame {
     const ClosureAtom *closure;
@@ -38,24 +40,6 @@ private:
   const SExpr *makeList(std::vector<const SExpr *>::size_type size);
 
 public:
-  class RuntimeException : public std::exception {
-    friend std::ostream &operator<<(std::ostream &o,
-                                    const VM::RuntimeException &re);
-
-  private:
-    std::string _msg;
-    const Env globals;
-    const std::vector<const SExpr *> stack;
-    const std::vector<CallFrame> frames;
-
-  public:
-    RuntimeException(const std::string &msg, Env globals,
-                     std::vector<const SExpr *> stack,
-                     std::vector<CallFrame> frames);
-
-    virtual const char *what() const noexcept override;
-  };
-
   VM();
   const SExpr *exec(const FnAtom *main);
 
@@ -72,7 +56,5 @@ template <> inline const NilAtom *VM::alloc() { return NilAtom::getInstance(); }
 template <> inline const BoolAtom *VM::alloc(bool &&val) {
   return BoolAtom::getInstance(val);
 }
-
-std::ostream &operator<<(std::ostream &o, const VM::RuntimeException &re);
 
 #endif


### PR DESCRIPTION
# Implement tracing garbage collection
Instead of using `std::make_shared<T>` and reference counting, memory allocation is now handled by the virtual machine (via `alloc<T>`). The virtual machine implements a naive [Tri-color marking](https://en.wikipedia.org/wiki/Tracing_garbage_collection#Tri-color_marking) algorithm to determine the reachability of any `SExpr` allocated.

### Feature changes
- `alloc<T>`, `cast<T>` and `dynCast<T>` now always enforces const correctness by returning `const T`
- Much more performant `cast<T>` and `dynCast<T>` using SExpr's RTTI instead of C++'s
- Singleton `NilAtom` and `BoolAtom`
- Caching `IntAtom` from -16 to 256

### Other changes
- Enable `UndefinedBehaviorSanitizer` (UBSan) and `AddressSanitizer` (ASan) and symbolication (`-g`) by default.
- Enable extra warnings `-pedantic` `-Wall` `-Wextra`

### 32nd fibonacci number benchmark

**Master**
```
2.98s user 0.01s system 94% cpu 3.176 total
```
**gc**
```
1.32s user 0.01s system 99% cpu 1.335 total
```

About 2x performance improvement