### PR TITLE
Clean up preprocessor macros

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@ CXX = g++
 CXXFLAGS = -std=c++20 $(CXXFLAGS_ASAN) $(CXXFLAGS_WARN) $(CXXFLAGS_EXTRA)
 CXXFLAGS_ASAN = -fsanitize=address,undefined -g
 CXXFLAGS_WARN = -pedantic -Wall -Wextra -Wno-gnu-label-as-value
-CXXFLAGS_EXTRA =
+CXXFLAGS_EXTRA = -O2
 
 PERCENT = %
 define NEWLINE

--- a/src/runtime/CPPFnImpls.cpp
+++ b/src/runtime/CPPFnImpls.cpp
@@ -1,8 +1,6 @@
 #include "CPPFnImpls.hpp"
 #include "../sexpr/Bool.hpp"
 #include "../sexpr/Cast.cpp"
-#include "../sexpr/Closure.hpp"
-#include "../sexpr/NatFn.hpp"
 #include "../sexpr/Nil.hpp"
 #include "../sexpr/Num.hpp"
 #include "../sexpr/SExprs.hpp"
@@ -18,51 +16,6 @@
 using namespace sexpr;
 using namespace runtime;
 
-#define MATH_CMP_OP(name, op)                                                  \
-  const SExpr &name(StackIter params, const uint8_t argc, VM &vm) {            \
-    const auto prev = cast<Num>(params->get()).val;                            \
-    ++params;                                                                  \
-    for (uint8_t i{1}; i < argc; ++i) {                                        \
-      if (!(prev op cast<Num>(params->get()).val)) {                           \
-        return vm.freeStore.alloc<Bool>(false);                                \
-      }                                                                        \
-      ++params;                                                                \
-    }                                                                          \
-    return vm.freeStore.alloc<Bool>(true);                                     \
-  }
-
-#define MATH_CUM_OP(name, op, init)                                            \
-  const SExpr &name(StackIter params, const uint8_t argc, VM &vm) {            \
-    auto res = init;                                                           \
-    for (uint8_t i{0}; i < argc; ++i) {                                        \
-      res op cast<Num>(params->get()).val;                                     \
-      ++params;                                                                \
-    }                                                                          \
-    return vm.freeStore.alloc<Num>(res);                                       \
-  }
-
-#define MATH_DIM_OP(name, op, unaryOp)                                         \
-  const SExpr &name(StackIter params, const uint8_t argc, VM &vm) {            \
-    if (argc == 1) {                                                           \
-      return vm.freeStore.alloc<Num>(unaryOp cast<Num>(params->get()).val);    \
-    }                                                                          \
-    auto res = cast<Num>(params->get()).val;                                   \
-    ++params;                                                                  \
-    for (uint8_t i{1}; i < argc; ++i) {                                        \
-      res op cast<Num>(params->get()).val;                                     \
-      ++params;                                                                \
-    }                                                                          \
-    return vm.freeStore.alloc<Num>(res);                                       \
-  }
-
-#define PRED_OP(name, cond)                                                    \
-  const SExpr &name(StackIter params, [[maybe_unused]] const uint8_t argc,     \
-                    VM &vm) {                                                  \
-    return vm.freeStore.alloc<Bool>(cond);                                     \
-  }
-
-PRED_OP(runtime::lispIsSym, isa<Sym>(params->get()));
-
 long genSymCnt = 0;
 const SExpr &runtime::lispGenSym([[maybe_unused]] StackIter params,
                                  [[maybe_unused]] const uint8_t argc, VM &vm) {
@@ -72,16 +25,6 @@ const SExpr &runtime::lispGenSym([[maybe_unused]] StackIter params,
   return vm.freeStore.alloc<Sym>(ss.str());
 }
 
-PRED_OP(runtime::lispIsNum, isa<Num>(params->get()));
-MATH_CMP_OP(runtime::lispNumEq, ==);
-MATH_CMP_OP(runtime::lispGt, >);
-MATH_CMP_OP(runtime::lispGteq, >=);
-MATH_CMP_OP(runtime::lispLt, <);
-MATH_CMP_OP(runtime::lispLteq, <=);
-MATH_CUM_OP(runtime::lispAdd, +=, 0.0);
-MATH_CUM_OP(runtime::lispMult, *=, 1.0);
-MATH_DIM_OP(runtime::lispSub, -=, 0.0 -);
-MATH_DIM_OP(runtime::lispDiv, /=, 1.0 /);
 const SExpr &runtime::lispAbs(StackIter params,
                               [[maybe_unused]] const uint8_t argc, VM &vm) {
   return vm.freeStore.alloc<Num>(abs(cast<Num>(params->get()).val));
@@ -94,7 +37,6 @@ const SExpr &runtime::lispMod(StackIter params,
   return vm.freeStore.alloc<Num>(std::fmod(lhs, rhs));
 }
 
-PRED_OP(runtime::lispIsStr, isa<String>(params->get()));
 const SExpr &runtime::lispStrLen(StackIter params,
                                  [[maybe_unused]] const uint8_t argc, VM &vm) {
   return vm.freeStore.alloc<Num>(cast<String>(params->get()).escaped.size());
@@ -109,8 +51,8 @@ const SExpr &runtime::lispStrSub(StackIter params,
     ss << "\"" << str.escaped.substr(pos, end - pos) << "\"";
   } catch (std::out_of_range &ofr) {
     std::stringstream ess;
-    ess << "Invalid range to substring for " << str.literal << " (" << pos
-        << ", " << end << ")";
+    ess << "Invalid range to substring for " << str.val << " (" << pos << ", "
+        << end << ")";
     throw std::invalid_argument(ess.str());
   }
   return vm.freeStore.alloc<String>(ss.str());
@@ -139,8 +81,6 @@ const SExpr &runtime::lispToStr(StackIter params, const uint8_t argc, VM &vm) {
   return vm.freeStore.alloc<String>(ss.str());
 }
 
-PRED_OP(runtime::lispIsNull, isa<Nil>(params->get()));
-PRED_OP(runtime::lispIsCons, isa<SExprs>(params->get()));
 const SExpr &runtime::lispCons(StackIter params,
                                [[maybe_unused]] const uint8_t argc, VM &vm) {
   return vm.freeStore.alloc<SExprs>(params->get(), *(params + 1));
@@ -216,12 +156,6 @@ const SExpr &runtime::lispEqual(StackIter params,
   return vm.freeStore.alloc<Bool>(lhs == rhs);
 }
 
-const SExpr &runtime::lispIsProc(StackIter params,
-                                 [[maybe_unused]] const uint8_t argc, VM &vm) {
-  return vm.freeStore.alloc<Bool>(isa<Closure>(params->get()) ||
-                                  isa<NatFn>(params->get()));
-}
-
 const SExpr &runtime::lispApply(StackIter params, const uint8_t argc, VM &vm) {
   const auto &newArgs = (params + argc - 1)->get();
 
@@ -234,8 +168,3 @@ const SExpr &runtime::lispApply(StackIter params, const uint8_t argc, VM &vm) {
 
   return vm.freeStore.alloc<Nil>();
 }
-
-#undef MATH_CMP_OP
-#undef MATH_CUM_OP
-#undef MATH_DIM_OP
-#undef PRED_OP

--- a/src/runtime/CPPFnImpls.hpp
+++ b/src/runtime/CPPFnImpls.hpp
@@ -1,42 +1,90 @@
 #ifndef LISP_SRC_RUNTIME_NATFNIMPLS_HPP_
 #define LISP_SRC_RUNTIME_NATFNIMPLS_HPP_
 
+#include "../sexpr/Bool.hpp"
 #include "CPPFn.hpp"
+#include "VM.hpp"
+#include <cstddef>
+#include <functional>
 #include <memory>
 #include <vector>
 
 namespace runtime {
 
-CPPFn lispIsSym;
+template <typename T, template <typename> typename Op>
+const sexpr::SExpr &lispCmpOp(StackIter params, const uint8_t argc, VM &vm) {
+  Op<typename T::ValueType> op;
+  typename T::ValueType prev = cast<T>(params->get()).val;
+  ++params;
+  for (uint8_t i{1}; i < argc; ++i) {
+    typename T::ValueType cur = cast<T>(params->get()).val;
+    if (!op(prev, cur)) {
+      return vm.freeStore.alloc<sexpr::Bool>(false);
+    }
+    prev = cur;
+    ++params;
+  }
+  return vm.freeStore.alloc<sexpr::Bool>(true);
+}
+
+template <typename T, template <typename> typename Op, auto init>
+const sexpr::SExpr &lispAcum(StackIter params, const uint8_t argc, VM &vm) {
+  Op<typename T::ValueType> op;
+  typename T::ValueType acc = init;
+  for (uint8_t i{0}; i < argc; ++i) {
+    acc = op(acc, cast<T>(params->get()).val);
+    ++params;
+  }
+  return vm.freeStore.alloc<T>(acc);
+}
+
+template <typename T, template <typename> typename BinOp,
+          template <typename> typename UniOp>
+const sexpr::SExpr &lispDim(StackIter params, const uint8_t argc, VM &vm) {
+  UniOp<typename T::ValueType> uniOp;
+  typename T::ValueType acc = cast<T>(params->get()).val;
+  if (argc == 1) {
+    return vm.freeStore.alloc<T>(uniOp(acc));
+  }
+  ++params;
+  BinOp<typename T::ValueType> biOp;
+  for (uint8_t i{1}; i < argc; ++i) {
+    acc = biOp(acc, cast<T>(params->get()).val);
+    ++params;
+  }
+  return vm.freeStore.alloc<T>(acc);
+}
+
+template <typename... T>
+const sexpr::SExpr &lispTypePred(StackIter params,
+                                 [[maybe_unused]] const uint8_t argc, VM &vm) {
+  return vm.freeStore.alloc<sexpr::Bool>((isa<T>(params->get()) || ...));
+}
+
+template <class T> struct inverse {
+  constexpr auto operator()(const T &x) const { return 1.0 / x; }
+};
+
 CPPFn lispGenSym;
 
-CPPFn lispIsNum;
 CPPFn lispNumEq;
 CPPFn lispGt;
 CPPFn lispGteq;
 CPPFn lispLt;
 CPPFn lispLteq;
-CPPFn lispAdd;
-CPPFn lispSub;
-CPPFn lispMult;
-CPPFn lispDiv;
 CPPFn lispAbs;
 CPPFn lispMod;
 
-CPPFn lispIsStr;
 CPPFn lispStrLen;
 CPPFn lispStrSub;
 CPPFn lispStrCon;
 CPPFn lispToStr;
 
-CPPFn lispIsNull;
-CPPFn lispIsCons;
 CPPFn lispCons;
 CPPFn lispCar;
 CPPFn lispCdr;
 
 CPPFn lispDis;
-CPPFn lispIsClosure;
 CPPFn lispDisplay;
 CPPFn lispNewline;
 
@@ -46,8 +94,6 @@ CPPFn lispError;
 CPPFn lispEq;
 CPPFn lispEqv;
 CPPFn lispEqual;
-
-CPPFn lispIsProc;
 
 CPPFn lispApply;
 

--- a/src/runtime/Env.hpp
+++ b/src/runtime/Env.hpp
@@ -25,15 +25,12 @@ private:
 
 public:
   void def(const sexpr::Sym &sym, const sexpr::SExpr &val);
-
   void set(const sexpr::Sym &sym, const sexpr::SExpr &val);
 
   const SymTable &getSymTable() const;
-
   const sexpr::SExpr &find(const sexpr::Sym &sym);
 
   void regMacro(const sexpr::Sym &sym);
-
   bool isMacro(const sexpr::Sym &sym);
 };
 

--- a/src/runtime/FreeStore.cpp
+++ b/src/runtime/FreeStore.cpp
@@ -101,7 +101,8 @@ FreeStore::FreeStore(
     : globals(globals), stack(stack), callFrames(callFrames),
       openUpvals(openUpvals), enableGC(false),
       gcHeapSize(FREESTORE_INIT_HEAP_SIZE) {
-  for (double i{FREESTORE_INT_CACHE_MIN}; i <= FREESTORE_INT_CACHE_MAX; i++) {
+  for (Num::ValueType i{FREESTORE_INT_CACHE_MIN}; i <= FREESTORE_INT_CACHE_MAX;
+       i++) {
     intCache.push_back(std::make_unique<Num>(i));
   }
 }

--- a/src/runtime/FreeStore.hpp
+++ b/src/runtime/FreeStore.hpp
@@ -69,10 +69,12 @@ template <> inline const sexpr::Undefined &FreeStore::alloc() {
 template <> inline const sexpr::Nil &FreeStore::alloc() {
   return sexpr::Nil::getInstance();
 }
-template <> inline const sexpr::Bool &FreeStore::alloc(bool &&val) {
+template <>
+inline const sexpr::Bool &FreeStore::alloc(sexpr::Bool::ValueType &&val) {
   return sexpr::Bool::getInstance(val);
 }
-template <> inline const sexpr::Num &FreeStore::alloc(double &val) {
+template <>
+inline const sexpr::Num &FreeStore::alloc(sexpr::Num::ValueType &val) {
   if (val >= FREESTORE_INT_CACHE_MIN && val <= FREESTORE_INT_CACHE_MAX &&
       floor(val) == val) {
     return *intCache.at(val - FREESTORE_INT_CACHE_MIN).get();

--- a/src/sexpr/Bool.cpp
+++ b/src/sexpr/Bool.cpp
@@ -5,7 +5,7 @@
 
 using namespace sexpr;
 
-Bool::Bool(const bool val) : Atom(SExpr::Type::BOOL), val(val) {}
+Bool::Bool(Bool::ValueType val) : Atom(SExpr::Type::BOOL), val(val) {}
 
 Bool Bool::_true(true);
 Bool Bool::_false(false);
@@ -21,7 +21,7 @@ bool Bool::equals(const SExpr &other) const {
   return false;
 }
 
-Bool &Bool::getInstance(const bool val) {
+Bool &Bool::getInstance(const Bool::ValueType val) {
   if (val) {
     return Bool::_true;
   }

--- a/src/sexpr/Bool.hpp
+++ b/src/sexpr/Bool.hpp
@@ -9,8 +9,11 @@
 namespace sexpr {
 
 class Bool final : public Atom {
+public:
+  using ValueType = bool;
+
 protected:
-  explicit Bool(const bool val);
+  explicit Bool(ValueType val);
 
   static Bool _true;
   static Bool _false;
@@ -19,9 +22,9 @@ protected:
   bool equals(const SExpr &other) const override;
 
 public:
-  const bool val;
+  const ValueType val;
 
-  static Bool &getInstance(const bool val);
+  static Bool &getInstance(const ValueType val);
   static bool toBool(const SExpr &sExpr);
   static bool classOf(const SExpr &sExpr);
   static std::string getTypeName();

--- a/src/sexpr/Num.cpp
+++ b/src/sexpr/Num.cpp
@@ -8,7 +8,8 @@
 using namespace sexpr;
 
 std::ostream &Num::serialize(std::ostream &o) const {
-  return o << std::setprecision(std::numeric_limits<double>::max_digits10)
+  return o << std::setprecision(
+                  std::numeric_limits<Num::ValueType>::max_digits10)
            << val;
 }
 
@@ -19,7 +20,7 @@ bool Num::equals(const SExpr &other) const {
   return false;
 }
 
-Num::Num(const double val) : Atom(SExpr::Type::NUM), val(val) {}
+Num::Num(const Num::ValueType val) : Atom(SExpr::Type::NUM), val(val) {}
 
 bool Num::classOf(const SExpr &sExpr) { return sExpr.type == SExpr::Type::NUM; }
 

--- a/src/sexpr/Num.hpp
+++ b/src/sexpr/Num.hpp
@@ -13,9 +13,11 @@ protected:
   bool equals(const SExpr &other) const override;
 
 public:
-  explicit Num(const double val);
+  using ValueType = double;
 
-  const double val;
+  explicit Num(const ValueType val);
+
+  const ValueType val;
 
   static bool classOf(const SExpr &sExpr);
   static std::string getTypeName();

--- a/src/sexpr/String.cpp
+++ b/src/sexpr/String.cpp
@@ -5,24 +5,24 @@
 
 using namespace sexpr;
 
-std::string String::escape(const std::string literal) {
+String::ValueType String::escape(const String::ValueType literal) {
   auto res = literal;
   res = std::regex_replace(res, std::regex("\\\\\""), "\"");
   res = std::regex_replace(res, std::regex("\\\\\\\\"), "\\");
   return res.substr(1, res.size() - 2);
 }
 
-std::ostream &String::serialize(std::ostream &o) const { return o << literal; }
+std::ostream &String::serialize(std::ostream &o) const { return o << val; }
 
 bool String::equals(const SExpr &other) const {
   if (isa<String>(other)) {
-    return literal == cast<String>(other).literal;
+    return val == cast<String>(other).val;
   }
   return false;
 }
 
-String::String(const std::string literal)
-    : Atom(SExpr::Type::STR), literal(literal), escaped(escape(literal)) {}
+String::String(const String::ValueType literal)
+    : Atom(SExpr::Type::STR), val(literal), escaped(escape(literal)) {}
 
 bool String::classOf(const SExpr &sExpr) {
   return sExpr.type == SExpr::Type::STR;

--- a/src/sexpr/String.hpp
+++ b/src/sexpr/String.hpp
@@ -8,18 +8,21 @@
 namespace sexpr {
 
 class String final : public Atom {
+public:
+  using ValueType = std::string;
+
 private:
-  static std::string escape(const std::string literal);
+  static ValueType escape(const ValueType literal);
 
 protected:
   std::ostream &serialize(std::ostream &o) const override;
   bool equals(const SExpr &other) const override;
 
 public:
-  explicit String(const std::string literal);
+  explicit String(const ValueType val);
 
-  const std::string literal;
-  const std::string escaped;
+  const ValueType val;
+  const ValueType escaped;
 
   static bool classOf(const SExpr &sExpr);
   static std::string getTypeName();

--- a/src/sexpr/Sym.cpp
+++ b/src/sexpr/Sym.cpp
@@ -20,8 +20,8 @@ bool Sym::EqualFunction::operator()(const Sym &lhs, const Sym &rhs) const {
   return lhs.hash == rhs.hash;
 }
 
-Sym::Sym(std::string val)
-    : Atom(SExpr::Type::SYM), val(val), hash(std::hash<std::string>()(val)) {}
+Sym::Sym(const ValueType val)
+    : Atom(SExpr::Type::SYM), val(val), hash(std::hash<ValueType>()(val)) {}
 
 bool Sym::classOf(const SExpr &sExpr) { return sExpr.type == SExpr::Type::SYM; }
 

--- a/src/sexpr/Sym.hpp
+++ b/src/sexpr/Sym.hpp
@@ -23,10 +23,12 @@ public:
     bool operator()(const Sym &lhs, const Sym &rhs) const;
   };
 
-  const std::string val;
+  using ValueType = std::string;
+
+  const ValueType val;
   const size_t hash;
 
-  explicit Sym(std::string val);
+  explicit Sym(const ValueType val);
 
   static bool classOf(const SExpr &sExpr);
   static std::string getTypeName();


### PR DESCRIPTION
### Replace preprocessor macros with templates

Replace C style preprocessor macros with templates when defining built-in functions.
Add a `ValueType` alias for Sexprs that wraps a C++ objects (`String`s, `Nums`s).
Also set `-O2` optimization flag as default.