### PR TITLE
Fast instruction/base pointers

### DIFF
--- a/src/runtime/CallFrame.hpp
+++ b/src/runtime/CallFrame.hpp
@@ -9,8 +9,8 @@ namespace runtime {
 
 struct CallFrame {
   const sexpr::Closure &closure;
-  code::InstrPtr ip;
-  runtime::StackPtr bp;
+  const runtime::StackPtr bp;
+  const code::InstrPtr ip;
 };
 
 } // namespace runtime

--- a/src/runtime/FreeStore.cpp
+++ b/src/runtime/FreeStore.cpp
@@ -21,6 +21,7 @@ void FreeStore::gc() {
 
   black.clear();
 
+  grey.push_back(&closure->get());
   markGlobals();
   markStack();
   markCallFrames();
@@ -95,10 +96,11 @@ void FreeStore::markOpenUpvalues() {
 
 FreeStore::FreeStore(
     Env &globals,
+    std::optional<std::reference_wrapper<const sexpr::Closure>> &closure,
     std::vector<std::reference_wrapper<const sexpr::SExpr>> &stack,
     std::vector<CallFrame> &callFrames,
     std::unordered_map<StackPtr, std::shared_ptr<Upvalue>> &openUpvals)
-    : globals(globals), stack(stack), callFrames(callFrames),
+    : globals(globals), closure(closure), stack(stack), callFrames(callFrames),
       openUpvals(openUpvals), enableGC(false),
       gcHeapSize(FREESTORE_INIT_HEAP_SIZE) {
   for (Num::ValueType i{FREESTORE_INT_CACHE_MIN}; i <= FREESTORE_INT_CACHE_MAX;

--- a/src/runtime/FreeStore.hpp
+++ b/src/runtime/FreeStore.hpp
@@ -25,6 +25,7 @@ namespace runtime {
 class FreeStore {
 private:
   Env &globals;
+  std::optional<std::reference_wrapper<const sexpr::Closure>> &closure;
   std::vector<std::reference_wrapper<const sexpr::SExpr>> &stack;
   std::vector<CallFrame> &callFrames;
   std::unordered_map<StackPtr, std::shared_ptr<Upvalue>> &openUpvals;
@@ -47,10 +48,12 @@ private:
   void markOpenUpvalues();
 
 public:
-  FreeStore(Env &globals,
-            std::vector<std::reference_wrapper<const sexpr::SExpr>> &stack,
-            std::vector<CallFrame> &callFrames,
-            std::unordered_map<StackPtr, std::shared_ptr<Upvalue>> &openUpvals);
+  FreeStore(
+      Env &globals,
+      std::optional<std::reference_wrapper<const sexpr::Closure>> &closure,
+      std::vector<std::reference_wrapper<const sexpr::SExpr>> &stack,
+      std::vector<CallFrame> &callFrames,
+      std::unordered_map<StackPtr, std::shared_ptr<Upvalue>> &openUpvals);
 
   GCGuard startGC();
   GCGuard pauseGC();

--- a/src/runtime/VM.hpp
+++ b/src/runtime/VM.hpp
@@ -1,6 +1,8 @@
 #ifndef LISP_SRC_RUNTIME_VM_HPP_
 #define LISP_SRC_RUNTIME_VM_HPP_
 
+#include <functional>
+#include <optional>
 #define LISP_GC_HEAP_GROWTH_FACTOR 2
 #define LISP_GC_INIT_HEAP_SIZE 4096
 #define LISP_INT_CACHE_MAX 256.0
@@ -34,19 +36,15 @@ class VM {
 private:
   Env globals;
 
+  code::InstrPtr ip;
+  runtime::StackPtr bp;
+  std::optional<std::reference_wrapper<const sexpr::Closure>> closure;
+
   std::vector<std::reference_wrapper<const sexpr::SExpr>> stack;
   std::vector<CallFrame> callFrames;
   std::unordered_map<StackPtr, std::shared_ptr<Upvalue>> openUpvals;
 
   const sexpr::SExpr &eval(const sexpr::Prototype &main, bool withGC);
-
-  CallFrame &callFrame();
-  const sexpr::Closure &closure();
-  const sexpr::Prototype &fn();
-  const code::Code &code();
-
-  code::InstrPtr &instPtr();
-  runtime::StackPtr &basePtr();
 
   const sexpr::SExpr &readConst();
   uint8_t readByte();


### PR DESCRIPTION
# Represent instruction and base pointers as VM attributes

Instruction and base pointers were always the `bp` and `ip` attributes of the last element of `callFrames` (defined as `vector<CallFrame>`). This probably forces the compiler to store and retrieve them via memory access with high cache miss rate (i.e. `bp` and `ip` will be in different address each time a new call stack in pushed/popped).


This change will represent them as members within the VM itself, and only store and load them into the call stack on a `CALL` or `RETURN` opcode. This enables better cache caching behaviour and can even encourage the compiler to store them in registers if it's smart enough.

### 32nd fibonacci number benchmark

**`master`**
```
bin/lisp tests/recur.scm  0.61s user 0.00s system 99% cpu 0.617 total
```

**This PR**
```
bin/lisp tests/recur.scm  0.45s user 0.00s system 99% cpu 0.452 total
```

26.7% performance improvements