### PR TITLE
Runtime type pattern matching

### DIFF
--- a/src/compile/Compiler.hpp
+++ b/src/compile/Compiler.hpp
@@ -3,6 +3,7 @@
 
 #include "../code/Code.hpp"
 #include "../runtime/VM.hpp"
+#include "../sexpr/Cast.cpp"
 #include "../sexpr/Prototype.hpp"
 #include "../sexpr/SExpr.hpp"
 #include "../sexpr/SExprs.hpp"
@@ -13,10 +14,20 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <stdexcept>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 
 namespace compile {
+
+const sexpr::Sym BEGIN_SYM("begin");
+const sexpr::Sym QUOTE_SYM("quote");
+const sexpr::Sym SET_SYM("set!");
+const sexpr::Sym IF_SYM("if");
+const sexpr::Sym LAMBDA_SYM("lambda");
+const sexpr::Sym DEFINE_SYM("define");
+const sexpr::Sym DEFMACRO_SYM("defmacro");
 
 class Compiler {
 private:
@@ -31,7 +42,7 @@ private:
   SrcMap srcMap;
   SrcLoc curSrcLoc;
 
-  const sexpr::SExpr &argNames;
+  const sexpr::SExpr &param;
   const uint8_t arity;
   const bool variadic;
 
@@ -56,11 +67,104 @@ private:
   const sexpr::SExpr &parseSexprs(TokenIter &it, const TokenIter &end);
   const sexpr::SExpr &parseAtom(Token token);
 
+  template <typename T> class MatchedSExpr {
+  private:
+    const T &sExpr;
+    const std::function<void()> callBack;
+
+  public:
+    MatchedSExpr(const T &sExpr, const std::function<void()> callBack)
+        : sExpr(sExpr), callBack(callBack) {}
+    const T &get() const {
+      callBack();
+      return sExpr;
+    }
+  };
+
+  template <typename First, typename... Rest>
+  std::tuple<const MatchedSExpr<First>, const MatchedSExpr<Rest>...>
+  unpack(const sexpr::SExpr &sExpr) {
+    const auto &sExprs = sexpr::cast<sexpr::SExprs>(sExpr);
+    updateCurSrcLoc(sExprs);
+    if constexpr (sizeof...(Rest) != 0) {
+      return std::tuple_cat(
+          std::tuple<const MatchedSExpr<First>>(MatchedSExpr<First>(
+              cast<First>(sExprs.first),
+              [this, &sExprs]() { updateCurSrcLoc(sExprs); })),
+          unpack<Rest...>(sExprs.rest));
+    } else {
+      assertType<sexpr::Nil>(sExprs.rest);
+      return std::tuple<const MatchedSExpr<First>>(
+          MatchedSExpr<First>(cast<First>(sExprs.first),
+                              [this, &sExprs]() { updateCurSrcLoc(sExprs); }));
+    }
+  }
+
+  template <typename First, typename... Rest>
+  std::tuple<const MatchedSExpr<First>, const MatchedSExpr<Rest>...,
+             const MatchedSExpr<sexpr::SExpr>>
+  unpackPartial(const sexpr::SExpr &sExpr) {
+    const auto &sExprs = sexpr::cast<sexpr::SExprs>(sExpr);
+    updateCurSrcLoc(sExprs);
+    if constexpr (sizeof...(Rest) != 0) {
+      return std::tuple_cat(
+          std::tuple<const MatchedSExpr<First>>(MatchedSExpr<First>(
+              cast<First>(sExprs.first),
+              [this, &sExprs]() { updateCurSrcLoc(sExprs); })),
+          unpackPartial<Rest...>(sExprs.rest));
+    } else {
+      return std::tuple<const MatchedSExpr<First>, MatchedSExpr<sexpr::SExpr>>(
+          MatchedSExpr<First>(cast<First>(sExprs.first),
+                              [this, &sExprs]() { updateCurSrcLoc(sExprs); }),
+          MatchedSExpr<sexpr::SExpr>(
+              sExprs.rest, [this, &sExprs]() { updateCurSrcLoc(sExprs); }));
+    }
+  }
+
+  template <typename First, typename... Rest>
+  bool check(const sexpr::SExpr &sExpr) {
+    if (!isa<sexpr::SExprs>(sExpr)) {
+      return false;
+    }
+    const auto &sExprs = cast<sexpr::SExprs>(sExpr);
+    if constexpr (sizeof...(Rest) != 0) {
+      return isa<First>(sExprs.first) && check<Rest...>(sExprs.rest);
+    } else {
+      return isa<First>(sExprs.first);
+    }
+  }
+
+  bool matchForm(
+      const sexpr::SExpr &sExpr,
+      std::initializer_list<
+          std::tuple<const sexpr::Sym &,
+                     const std::function<void(MatchedSExpr<sexpr::SExpr>)>>>
+          rules,
+      std::optional<const std::function<void(MatchedSExpr<sexpr::Sym>,
+                                             MatchedSExpr<sexpr::SExpr>)>>
+          wildCardHandler = std::nullopt) {
+    if (!check<sexpr::Sym>(sExpr)) {
+      return false;
+    }
+    const auto &[sym, rest] = unpackPartial<sexpr::Sym>(sExpr);
+    for (const auto &[name, handler] : rules) {
+      if (name == sym.get()) {
+        handler(rest);
+        return true;
+      }
+    }
+    if (wildCardHandler) {
+      wildCardHandler->operator()(sym, rest);
+      return true;
+    }
+    return false;
+  }
+
   Compiler(const std::vector<std::string> source, SrcMap sourceLoc,
            const sexpr::SExpr &param, const sexpr::SExprs &body,
            Compiler &enclosing, runtime::VM &vm);
 
-  void updateCurSrcLoc(const sexpr::SExpr &sExpr);
+  void updateCurSrcLoc(const sexpr::SExprs &sExpr);
   std::optional<const std::size_t> resolveLocal(const sexpr::Sym &sym);
   std::optional<const std::size_t> resolveUpvalue(Compiler &caller,
                                                   const sexpr::Sym &sym);
@@ -80,26 +184,28 @@ private:
   code::InstrPtr emitConst(const sexpr::SExpr &sExpr);
   void patchJump(const code::InstrPtr idx);
 
-  const sexpr::SExpr &at(const unsigned int n, const sexpr::SExpr &sExpr);
   const sexpr::SExpr &last(const sexpr::SExpr &sExpr);
   unsigned int visitEach(const sexpr::SExpr &sExpr, Visitor visitor);
   void traverse(const sexpr::SExpr &sExpr, Visitor visitor);
+  void compileStmts(const sexpr::SExpr &sExpr);
+  void compileExprs(const sexpr::SExpr &sExpr);
   void compileStmt(const sexpr::SExpr &sExpr);
   void compileExpr(const sexpr::SExpr &sExpr);
-  void compileLambda(const sexpr::SExpr &sExpr);
-  void compileCall(const sexpr::SExprs &sExprs);
   void compileAtom(const sexpr::Atom &atom);
-  void compileSym(const sexpr::Sym &sym);
-  void compileQuote(const sexpr::SExpr &sExpr);
-  void compileDef(const sexpr::SExpr &sExpr);
-  void compileSet(const sexpr::SExpr &sExpr);
-  void compileIf(const sexpr::SExpr &sExpr);
-  void compileRet();
-  void execDefMacro(const sexpr::SExpr &sExpr);
+  void compileCall(const sexpr::SExprs &sExprs);
+  void emitDef(const MatchedSExpr<sexpr::SExpr> matched);
+  void emitSet(const MatchedSExpr<sexpr::SExpr> matched);
+  void emitSym(const sexpr::Sym &sym);
+  void emitQuote(const MatchedSExpr<sexpr::SExpr> matched);
+  void emitIf(const MatchedSExpr<sexpr::SExpr> matched);
+  void emitLambda(const MatchedSExpr<sexpr::SExpr> matched);
+  void emitRet();
+  void execDefMacro(const MatchedSExpr<sexpr::SExpr> matched);
   const sexpr::SExpr &execMacro(const sexpr::SExpr &macro);
 
-  void handleSyntaxError(const std::string grammar, const std::string expected,
-                         const sexpr::SExpr &actual);
+  void handleInvalidDef();
+  void handleTypeError(const std::string grammar, const std::string expected,
+                       const sexpr::SExpr &actual);
 
 public:
   Compiler(std::vector<std::string> source, runtime::VM &vm);

--- a/src/sexpr/Cast.cpp
+++ b/src/sexpr/Cast.cpp
@@ -2,23 +2,39 @@
 #define LISP_SRC_SEXPR_CAST_CPP_
 
 #include "../error/TypeError.hpp"
+#include "SExpr.hpp"
 #include <memory>
 #include <sstream>
 
 namespace sexpr {
 
-template <typename To, typename From> bool isa(From &f) {
-  return To::classOf(f);
+template <typename T> bool isa(const SExpr &f) { return T::classOf(f); }
+
+template <typename T> void assertType(const SExpr &f) {
+  if (!isa<T>(f)) {
+    std::stringstream ss;
+    ss << "Mismatched types. Expected " << T::getTypeName() << ", but got " << f
+       << ".";
+    throw error::TypeError(ss.str(), T::getTypeName(), f);
+  }
 }
 
-template <typename To, typename From> const To &cast(const From &f) {
-  if (isa<To>(f)) {
-    return static_cast<const To &>(f);
+template <typename First, typename Next, typename... Rest>
+void assertType(const SExpr &f) {
+  if (!(isa<First>(f) || isa<Next>(f) || (isa<Rest>(f) || ...))) {
+    std::string typeName =
+        "one of: (" + First::getTypeName() + ", " + Next::getTypeName();
+    ([&typeName] { typeName += ", " + Rest::getTypeName(); }(), ...);
+    typeName += ")";
+    std::stringstream ss;
+    ss << "Mismatched types. Expected " << typeName << ", but got " << f << ".";
+    throw error::TypeError(ss.str(), typeName, f);
   }
-  std::stringstream ss;
-  ss << "Mismatched types. Expected " << To::getTypeName() << ", but got " << f
-     << ".";
-  throw error::TypeError(ss.str(), To::getTypeName(), f);
+}
+
+template <typename T> const T &cast(const SExpr &f) {
+  assertType<T>(f);
+  return static_cast<const T &>(f);
 }
 
 } // namespace sexpr

--- a/src/sexpr/SExpr.cpp
+++ b/src/sexpr/SExpr.cpp
@@ -7,6 +7,10 @@ SExpr::SExpr(SExpr::Type type) : type(type) {}
 
 SExpr::~SExpr() {}
 
+bool SExpr::classOf([[maybe_unused]] const SExpr &sExpr) { return true; }
+
+std::string SExpr::getTypeName() { return "<S-expression>"; }
+
 std::ostream &sexpr::operator<<(std::ostream &o, const SExpr &sExpr) {
   return sExpr.serialize(o);
 }

--- a/src/sexpr/SExpr.hpp
+++ b/src/sexpr/SExpr.hpp
@@ -37,6 +37,9 @@ public:
   SExpr(const SExpr &) = delete;
   SExpr(const SExpr &&) = delete;
   SExpr &operator=(const SExpr &) = delete;
+
+  static bool classOf(const SExpr &sExpr);
+  static std::string getTypeName();
 };
 
 std::ostream &operator<<(std::ostream &o, const SExpr &sExpr);


### PR DESCRIPTION
# Implement runtime type pattern matching functions

Extends the current available runtime type matching facilities.

### New facilities

**`MatchedSExpr<T>`**

A wrapper for any kind of s-expression, calling `.get()` will return the wrapped s-expression and automatically update compiler's current source location.

**`check<Typename... Types>(sExpr)`**

Takes a single s-expression as parameter, and returns true if the `car` of every node _i_ is of `Types[i]`, return false otherwise.

**`unpack<Typename... Types>(sExpr)` and `unpackPartial<Typename... Types>(sExpr)`**

Takes a single s-expression as parameter. Cast the `car` of every node _i_ to `Types[i]`, and wraps it with `MatchedSExpr`, and collects them all into a single tuple, so it could be used for structured binding. `Unpack` asserts that the `cdr` of the last node is `Nil`, while `unpackPartial` will collect it into the tuple.

This eliminates the need of magic numbers, and the type pattern of a specific grammar can be expressed in the code itself.

Before

``` C++
const auto &test = cast<SExprs>(at(0, sExpr)).first;
const auto &conseq = cast<SExprs>(at(1, sExpr)).first;
const auto &alt = cast<SExprs>(at(2, sExpr)).first;
```

After

``` C++
const auto &[test, conseq, alt] = unpack<SExpr, SExpr, SExpr>(sExpr);
```

**`matchForm(sExpr, {{SYMBOL, handler}*}, wildcardHandler)`**

Takes a single s-expression, and an initializer list of _rules_, where each _rule_ is a tuple of a symbol and a call back function, if the s-expression is a list, and the first element matches the symbol, invoke the the callback function. Finally, if no symbol matches, the wildcardHandler is called.

This eliminates the nested type checks and symbol comparison.


Before

``` C++
if (isa<Sym>(sExprs.first)) {
    const auto &sym = cast<Sym>(sExprs.first);
    if (sym.val == "begin") {
      ...
      return;
    } else if (sym.val == "quote") {
      ...
      return;
    } else if (sym.val == "set!") {
      ...
      return;
    } else if (sym.val == "if") {
      ...
      return;
    } ...
```

After

``` C++
if (matchForm(
          sExpr,
          {{DEFINE_SYM,   [this](const auto &) { ... }},
           {DEFMACRO_SYM, [this](const auto &) { ... }},
           {QUOTE_SYM,    [this](const auto &matched) { ... }},
           {SET_SYM,      [this](const auto &matched) { ... }},
           ...
          [this, &sExpr](const auto sym, const auto) {
           ...
          })) {
  return;
}
```